### PR TITLE
Let PlainParseLine ignore \r

### DIFF
--- a/receiver/plain.go
+++ b/receiver/plain.go
@@ -65,6 +65,9 @@ func PlainParseLine(p []byte) ([]byte, float64, uint32, error) {
 	if p[i3-1] == '\n' {
 		i3--
 	}
+	if p[i3-1] == '\r' {
+		i3--
+	}
 
 	value, err := strconv.ParseFloat(unsafeString(p[i1+1:i2]), 64)
 	if err != nil || math.IsNaN(value) {


### PR DESCRIPTION
collectd and other graphite implementations send \r\n. Ignore \r for parsing the last Float.
Fixes lomik/carbon-clickhouse#1