### PR TITLE
upload to several tables

### DIFF
--- a/carbon/app.go
+++ b/carbon/app.go
@@ -184,6 +184,7 @@ func (app *App) Start() (err error) {
 		uploader.Path(conf.Data.Path),
 		uploader.ClickHouse(conf.ClickHouse.Url),
 		uploader.DataTable(conf.ClickHouse.DataTable),
+		uploader.DataTables(conf.ClickHouse.DataTables),
 		uploader.DataTimeout(conf.ClickHouse.DataTimeout.Value()),
 		uploader.TreeTable(conf.ClickHouse.TreeTable),
 		uploader.TreeDate(conf.ClickHouse.TreeDate),

--- a/carbon/config.go
+++ b/carbon/config.go
@@ -42,8 +42,10 @@ type commonConfig struct {
 }
 
 type clickhouseConfig struct {
-	Url            string    `toml:"url"`
-	DataTable      string    `toml:"data-table"`
+	Url        string   `toml:"url"`
+	DataTable  string   `toml:"data-table"`
+	DataTables []string `toml:"data-tables"`
+
 	DataTimeout    *Duration `toml:"data-timeout"`
 	TreeTable      string    `toml:"tree-table"`
 	TreeDateString string    `toml:"tree-date"`
@@ -113,6 +115,7 @@ func NewConfig() *Config {
 		ClickHouse: clickhouseConfig{
 			Url:            "http://localhost:8123/",
 			DataTable:      "graphite",
+			DataTables:     []string{},
 			TreeTable:      "graphite_tree",
 			TreeDateString: "2016-11-01",
 			DataTimeout: &Duration{


### PR DESCRIPTION
Hi,
This patch adds the ability to specify multiple tables to upload the data.
data-tables = ["graphite.graphite10", "graphite.graphite60", "graphite.graphite900", "graphite.graphite3600"]