### PR TITLE
build docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM golang:alpine as builder
+
+WORKDIR /go/src/github.com/lomik/carbon-clickhouse
+
+COPY . .
+
+RUN apk --no-cache add make git
+RUN make submodules
+
+RUN make
+
+FROM alpine:latest
+
+RUN apk --no-cache add ca-certificates
+WORKDIR /
+
+COPY --from=builder /go/src/github.com/lomik/carbon-clickhouse/carbon-clickhouse ./usr/bin/carbon-clickhouse
+
+CMD ["carbon-clickhouse"]
+


### PR DESCRIPTION
A simple docker image builder, simply run:

`
docker build -t carbon-clickhouse .
`

and

`
docker run --rm -ti carbon-clickhouse carbon-clickhouse -config-print-default
`

or

`
docker run -d carbon-clickhouse carbon-clickhouse -config /path/to/carbon-clickhouse.conf
`

only 18MB in size
