### PR TITLE
fix tags errors

### DIFF
--- a/receiver/telegraf_http_json.go
+++ b/receiver/telegraf_http_json.go
@@ -56,7 +56,7 @@ func TelegrafEncodeTags(tags map[string]string) string {
 	}
 
 	keys := make([]string, 0, len(tags))
-	for k, _ := range tags {
+	for k := range tags {
 		keys = append(keys, k)
 	}
 	sort.Strings(keys)

--- a/receiver/telegraf_http_json.go
+++ b/receiver/telegraf_http_json.go
@@ -63,10 +63,17 @@ func TelegrafEncodeTags(tags map[string]string) string {
 
 	var res bytes.Buffer
 	for i := 0; i < len(keys); i++ {
-		if i > 1 {
+		if i > 0 {
 			res.WriteByte('&')
 		}
-		res.WriteString(url.QueryEscape(keys[i]))
+
+		// `name` is reserved for metric, replace it as tag name
+		key := keys[i]
+		if key == "name" {
+			key = "_name"
+		}
+
+		res.WriteString(url.QueryEscape(key))
 		res.WriteByte('=')
 		res.WriteString(url.QueryEscape(tags[keys[i]]))
 	}


### PR DESCRIPTION
1. No `&` symbol after first tag pair
2. telegraf send `name` as tag name in some plugins (diskio for example), but is predefined for metric