### PR TITLE
added support for -1 as timestamp value in plain text format

### DIFF
--- a/receiver/plain_test.go
+++ b/receiver/plain_test.go
@@ -107,3 +107,11 @@ func TestPlainParseLine(t *testing.T) {
 		}
 	}
 }
+
+func TestPlainParseLineTimestampAsMinusOne(t *testing.T) {
+	str := "metric.name 42 -1"
+	_, _, timestamp, _ := PlainParseLine([]byte(str))
+	if timestamp == 4294967295 {
+		t.Fatalf("%d == %d", timestamp, 4294967295)
+	}
+}


### PR DESCRIPTION
Adding support for -1 as timestamp in plain format - use current timestamp upon arrival. Fix for #25 