### PR TITLE
Graphite templates from InfluxDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,4 +201,17 @@ drop-past = "0s"
 [pprof] 
 listen = "localhost:7007"
 enabled = false
+
+# You can use tag matching like in InfluxDB. Format is exactly the same.
+# It will parse all metrics that don't have tags yet.
+# For more information see https://docs.influxdata.com/influxdb/v1.7/supported_protocols/graphite/
+# Example:
+# [old_graphite]
+# enabled = true 
+# separator = "_"
+# tags = ["region=us-east", "zone=1c"]
+# templates = [
+#     "generated.* .measurement.cpu  metric=idle",
+#     "* host.measurement* template_match=none",
+# ] 
 ```

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ enabled = false
 # It will parse all metrics that don't have tags yet.
 # For more information see https://docs.influxdata.com/influxdb/v1.7/supported_protocols/graphite/
 # Example:
-# [old_graphite]
+# [convert_to_tagged]
 # enabled = true 
 # separator = "_"
 # tags = ["region=us-east", "zone=1c"]

--- a/carbon-clickhouse.go
+++ b/carbon-clickhouse.go
@@ -104,8 +104,6 @@ func main() {
 		log.Fatal(err)
 	}
 
-	log.Println("Config TagDesc: ", app.Config.TagDesc.TemplateDescs)
-
 	// config parsed successfully. Exit in check-only mode
 	if *checkConfig {
 		return

--- a/carbon-clickhouse.go
+++ b/carbon-clickhouse.go
@@ -104,6 +104,8 @@ func main() {
 		log.Fatal(err)
 	}
 
+	log.Println("Config TagDesc: ", app.Config.TagDesc.TemplateDescs)
+
 	// config parsed successfully. Exit in check-only mode
 	if *checkConfig {
 		return

--- a/carbon/app.go
+++ b/carbon/app.go
@@ -77,6 +77,11 @@ func (app *App) configure() error {
 		}
 	}
 
+	err = cfg.TagDesc.Configure()
+	if err != nil {
+		return err
+	}
+
 	app.Config = cfg
 
 	return nil
@@ -233,6 +238,7 @@ func (app *App) Start() (err error) {
 	if conf.Tcp.Enabled {
 		app.TCP, err = receiver.New(
 			"tcp://"+conf.Tcp.Listen,
+			app.Config.TagDesc,
 			receiver.ParseThreads(runtime.GOMAXPROCS(-1)*2),
 			receiver.WriteChan(app.writeChan),
 			receiver.DropFuture(uint32(conf.Tcp.DropFuture.Value().Seconds())),
@@ -249,6 +255,7 @@ func (app *App) Start() (err error) {
 	if conf.Udp.Enabled {
 		app.UDP, err = receiver.New(
 			"udp://"+conf.Udp.Listen,
+			app.Config.TagDesc,
 			receiver.ParseThreads(runtime.GOMAXPROCS(-1)*2),
 			receiver.WriteChan(app.writeChan),
 			receiver.DropFuture(uint32(conf.Udp.DropFuture.Value().Seconds())),
@@ -265,6 +272,7 @@ func (app *App) Start() (err error) {
 	if conf.Pickle.Enabled {
 		app.Pickle, err = receiver.New(
 			"pickle://"+conf.Pickle.Listen,
+			app.Config.TagDesc,
 			receiver.ParseThreads(runtime.GOMAXPROCS(-1)*2),
 			receiver.WriteChan(app.writeChan),
 			receiver.DropFuture(uint32(conf.Pickle.DropFuture.Value().Seconds())),
@@ -281,6 +289,7 @@ func (app *App) Start() (err error) {
 	if conf.Grpc.Enabled {
 		app.Grpc, err = receiver.New(
 			"grpc://"+conf.Grpc.Listen,
+			app.Config.TagDesc,
 			receiver.WriteChan(app.writeChan),
 			receiver.DropFuture(uint32(conf.Grpc.DropFuture.Value().Seconds())),
 			receiver.DropPast(uint32(conf.Grpc.DropPast.Value().Seconds())),
@@ -296,6 +305,7 @@ func (app *App) Start() (err error) {
 	if conf.Prometheus.Enabled {
 		app.Prometheus, err = receiver.New(
 			"prometheus://"+conf.Prometheus.Listen,
+			app.Config.TagDesc,
 			receiver.WriteChan(app.writeChan),
 			receiver.DropFuture(uint32(conf.Prometheus.DropFuture.Value().Seconds())),
 			receiver.DropPast(uint32(conf.Prometheus.DropPast.Value().Seconds())),
@@ -311,6 +321,7 @@ func (app *App) Start() (err error) {
 	if conf.TelegrafHttpJson.Enabled {
 		app.TelegrafHttpJson, err = receiver.New(
 			"telegraf+http+json://"+conf.TelegrafHttpJson.Listen,
+			app.Config.TagDesc,
 			receiver.WriteChan(app.writeChan),
 			receiver.DropFuture(uint32(conf.TelegrafHttpJson.DropFuture.Value().Seconds())),
 			receiver.DropPast(uint32(conf.TelegrafHttpJson.DropPast.Value().Seconds())),

--- a/carbon/config.go
+++ b/carbon/config.go
@@ -94,7 +94,7 @@ type Config struct {
 	TelegrafHttpJson telegrafHttpJsonConfig      `toml:"telegraf_http_json"`
 	Pprof            pprofConfig                 `toml:"pprof"`
 	Logging          []zapwriter.Config          `toml:"logging"`
-	TagDesc          tags.TagConfig              `toml:"old_graphite"`
+	TagDesc          tags.TagConfig              `toml:"convert_to_tagged"`
 }
 
 // NewConfig ...

--- a/carbon/config.go
+++ b/carbon/config.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/BurntSushi/toml"
 	"github.com/lomik/carbon-clickhouse/helper/config"
+	"github.com/lomik/carbon-clickhouse/helper/tags"
 	"github.com/lomik/carbon-clickhouse/uploader"
 	"github.com/lomik/zapwriter"
 )
@@ -93,6 +94,7 @@ type Config struct {
 	TelegrafHttpJson telegrafHttpJsonConfig      `toml:"telegraf_http_json"`
 	Pprof            pprofConfig                 `toml:"pprof"`
 	Logging          []zapwriter.Config          `toml:"logging"`
+	TagDesc          tags.TagConfig              `toml:"old_graphite"`
 }
 
 // NewConfig ...
@@ -153,6 +155,9 @@ func NewConfig() *Config {
 		},
 		Pprof: pprofConfig{
 			Listen:  "localhost:7007",
+			Enabled: false,
+		},
+		TagDesc: tags.TagConfig{
 			Enabled: false,
 		},
 	}

--- a/helper/tags/graphite.go
+++ b/helper/tags/graphite.go
@@ -125,8 +125,8 @@ func makeRegexp(filter string) *regexp.Regexp {
 		end = ""
 		filter = filter[:len(filter)-1]
 	}
-	newF := begin + strings.Replace(strings.Replace(filter, ".", "\\.", -1), "*", "[^\\.]*", -1) + end
-	return regexp.MustCompile(newF)
+	pattern := begin + strings.Replace(strings.Replace(filter, ".", "\\.", -1), "*", "[^\\.]*", -1) + end
+	return regexp.MustCompile(pattern)
 }
 
 func (cfg *TagConfig) Configure() error {
@@ -228,7 +228,7 @@ func (cfg *TagConfig) toGraphiteTagged(s string) (string, error) {
 			}
 		}
 
-		if bytes.HasSuffix([]byte(measurement), []byte("_")) {
+		if strings.HasSuffix(measurement, "_") {
 			measurement = measurement[:len(measurement)-1]
 		}
 

--- a/helper/tags/graphite.go
+++ b/helper/tags/graphite.go
@@ -220,7 +220,11 @@ func (cfg *TagConfig) toGraphiteTagged(s string) (string, error) {
 				measurement += strings.Join(names[i:], cfg.Separator)
 				break Metric
 			default:
-				tagMap[desc.Template[i]] = name
+				if prefix, ok := tagMap[desc.Template[i]]; ok {
+					tagMap[desc.Template[i]] = prefix + cfg.Separator + name
+				} else {
+					tagMap[desc.Template[i]] = name
+				}
 			}
 		}
 

--- a/helper/tags/graphite.go
+++ b/helper/tags/graphite.go
@@ -197,6 +197,11 @@ func (cfg *TagConfig) toGraphiteTagged(s string) (string, error) {
 		measurement := ""
 		tags := ""
 
+		if len(names) != len(desc.Template) && !strings.HasSuffix(desc.Template[len(desc.Template)-1], "*") ||
+			len(names) < len(desc.Template) {
+			continue
+		}
+
 	Metric:
 		for i, name := range names {
 			switch desc.Template[i] {

--- a/helper/tags/graphite.go
+++ b/helper/tags/graphite.go
@@ -134,27 +134,34 @@ func (cfg *TagConfig) Configure() error {
 	makeTagMap(cfg.TagMap, cfg.Tags)
 
 	for _, s := range cfg.Templates {
-		descs := strings.Split(s, " ")
-		if len(descs) > 3 {
+		dirtyTokens := strings.Split(s, " ")
+		tokens := dirtyTokens[:0]
+		for _, token := range dirtyTokens {
+			trimmed := strings.TrimSpace(token)
+			if trimmed != "" {
+				tokens = append(tokens, trimmed)
+			}
+		}
+		if len(tokens) > 3 {
 			return fmt.Errorf("wrong template format")
 		}
 		var filter string
 		var template string
 		var tags string
-		if len(descs) == 2 {
-			if strings.Contains(descs[1], "=") {
-				tags = descs[1]
-				template = descs[0]
+		if len(tokens) == 2 {
+			if strings.Contains(tokens[1], "=") {
+				tags = tokens[1]
+				template = tokens[0]
 			} else {
-				template = descs[1]
-				filter = descs[0]
+				template = tokens[1]
+				filter = tokens[0]
 			}
-		} else if len(descs) == 3 {
-			filter = descs[0]
-			template = descs[1]
-			tags = descs[2]
+		} else if len(tokens) == 3 {
+			filter = tokens[0]
+			template = tokens[1]
+			tags = tokens[2]
 		} else {
-			template = descs[0]
+			template = tokens[0]
 		}
 
 		newDesc := TemplateDesc{}

--- a/helper/tags/graphite_template_test.go
+++ b/helper/tags/graphite_template_test.go
@@ -9,8 +9,7 @@ var graphiteTemplateTestTable = []graphiteTestCase{
 	{"some.metric", "metric?tag0=value0&tag1=value1", false},
 	{"aval.bval.cval.app", "app?a=aval&b=bval&c=cval&tag0=value0&tag1=value1", false},
 	{"stats.local.a.b.c.d", "a_b_c_d?host=local&region=us-west&tag0=value0&tag1=new-value1", false},
-	//{"some.metric;k=a;k=_;k2=3;k=0;k=42", "some.metric?k=42&k2=3", false}, // strange order but as in python-carbon
-	//{"some.metric", "some.metric", false},
+	{"multi.tags.aval.m1.m2.m3", "m1_m2_m3?a=aval&tag0=new-value0&tag1=value1", false},
 }
 
 func TestTemplates(t *testing.T) {
@@ -21,7 +20,7 @@ func TestTemplates(t *testing.T) {
 		Templates: []string{
 			"*.app a.b.c.measurement",
 			"stats.* .host.measurement* region=us-west,tag1=new-value1",
-			//"stats.* .host.measurement.field",
+			"multi.tags.* ..a.measurement*    tag0=new-value0",
 			".measurement*",
 		},
 	}

--- a/helper/tags/graphite_template_test.go
+++ b/helper/tags/graphite_template_test.go
@@ -1,0 +1,41 @@
+package tags
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+var graphiteTemplateTestTable = []graphiteTestCase{
+	{"some.metric", "metric?tag0=value0&tag1=value1", false},
+	{"aval.bval.cval.app", "app?a=aval&b=bval&c=cval&tag0=value0&tag1=value1", false},
+	{"stats.local.a.b.c.d", "a_b_c_d?host=local&region=us-west&tag0=value0&tag1=new-value1", false},
+	//{"some.metric;k=a;k=_;k2=3;k=0;k=42", "some.metric?k=42&k2=3", false}, // strange order but as in python-carbon
+	//{"some.metric", "some.metric", false},
+}
+
+func TestTemplates(t *testing.T) {
+	assert := assert.New(t)
+	tagCfg := TagConfig{Enabled: true,
+		Separator: "_",
+		Tags:      []string{"tag0=value0", "tag1=value1"},
+		Templates: []string{
+			"*.app a.b.c.measurement",
+			"stats.* .host.measurement* region=us-west,tag1=new-value1",
+			//"stats.* .host.measurement.field",
+			".measurement*",
+		},
+	}
+	tagCfg.Configure()
+
+	for i := 0; i < len(graphiteTemplateTestTable); i++ {
+		n, err := Graphite(tagCfg, graphiteTemplateTestTable[i].in)
+
+		if !graphiteTemplateTestTable[i].err {
+			assert.NoError(err)
+		} else {
+			assert.Error(err)
+		}
+
+		assert.Equal(graphiteTemplateTestTable[i].ex, n)
+	}
+}

--- a/helper/tags/graphite_test.go
+++ b/helper/tags/graphite_test.go
@@ -25,7 +25,7 @@ func TestGraphite(t *testing.T) {
 	assert := assert.New(t)
 
 	for i := 0; i < len(graphiteTestTable); i++ {
-		n, err := Graphite(graphiteTestTable[i].in)
+		n, err := Graphite(DisabledTagConfig(), graphiteTestTable[i].in)
 
 		if !graphiteTestTable[i].err {
 			assert.NoError(err)
@@ -39,7 +39,7 @@ func TestGraphite(t *testing.T) {
 
 func BenchmarkGraphite(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		_, err := Graphite(graphiteBenchmarkMetric)
+		_, err := Graphite(DisabledTagConfig(), graphiteBenchmarkMetric)
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/receiver/base.go
+++ b/receiver/base.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/lomik/carbon-clickhouse/helper/RowBinary"
 	"github.com/lomik/carbon-clickhouse/helper/stop"
+	"github.com/lomik/carbon-clickhouse/helper/tags"
 	"go.uber.org/zap"
 )
 
@@ -34,10 +35,11 @@ type Base struct {
 	dropPastSeconds   uint32
 	writeChan         chan *RowBinary.WriteBuffer
 	logger            *zap.Logger
+	Tags              tags.TagConfig
 }
 
-func NewBase(logger *zap.Logger) Base {
-	return Base{logger: logger}
+func NewBase(logger *zap.Logger, config tags.TagConfig) Base {
+	return Base{logger: logger, Tags: config}
 }
 
 func sendUint64Counter(send func(metric string, value float64), metric string, value *uint64) {

--- a/receiver/grpc.go
+++ b/receiver/grpc.go
@@ -100,7 +100,7 @@ func (g *GRPC) doStore(requestCtx context.Context, in *pb.Payload, confirmRequir
 			return errors.New("points is empty")
 		}
 
-		name, err := tags.Graphite(m.Metric)
+		name, err := tags.Graphite(g.Tags, m.Metric)
 		if err != nil {
 			return err
 		}

--- a/receiver/pickle_parser.go
+++ b/receiver/pickle_parser.go
@@ -48,7 +48,7 @@ func (base *Base) PickleParseBytes(ctx context.Context, b []byte, now uint32) {
 	}
 
 	pickle.ParseMessage(b, func(name string, value float64, timestamp int64) {
-		name, err := tags.Graphite(name)
+		name, err := tags.Graphite(base.Tags, name)
 		if err != nil {
 			// @TODO: log?
 			return

--- a/receiver/receiver.go
+++ b/receiver/receiver.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/lomik/carbon-clickhouse/helper/RowBinary"
+	"github.com/lomik/carbon-clickhouse/helper/tags"
 	"github.com/lomik/zapwriter"
 )
 
@@ -60,13 +61,13 @@ func DropPast(seconds uint32) Option {
 }
 
 // New creates udp, tcp, pickle receiver
-func New(dsn string, opts ...Option) (Receiver, error) {
+func New(dsn string, config tags.TagConfig, opts ...Option) (Receiver, error) {
 	u, err := url.Parse(dsn)
 	if err != nil {
 		return nil, err
 	}
 
-	base := NewBase(zapwriter.Logger(strings.Replace(u.Scheme, "+", "_", -1)))
+	base := NewBase(zapwriter.Logger(strings.Replace(u.Scheme, "+", "_", -1)), config)
 
 	for _, optApply := range opts {
 		optApply(&base)


### PR DESCRIPTION
One more way to represent metrics with tags: data is received in old graphite format (i.e. without tags separated by `;`), and then influx is filtering it and is adding some tags according to templates specified in config ([doc](https://docs.influxdata.com/influxdb/v1.7/supported_protocols/graphite/)). 

In case somebody wants to switch from influx to clickhouse, it might be helpful to introduce such template format in carbon-clickhouse too.

It would be great if you said what do you think about it. Thanks.