### PR TITLE
Add a delay when upload fails

### DIFF
--- a/uploader/base.go
+++ b/uploader/base.go
@@ -159,6 +159,8 @@ func (u *Base) uploadWorker(ctx context.Context) {
 					zap.Error(err),
 					zap.Duration("time", time.Since(startTime)),
 				)
+
+				time.Sleep(time.Second)
 			} else {
 				atomic.AddUint32(&u.stat.uploaded, 1)
 				logger.Info("handle success",


### PR DESCRIPTION
When uploads to Clickhouse are failing for any reason (e.g. we're restarting it) then `carbon-clickhouse` goes into CPU-eating loop consuming more and more resources when more files are accumulated in buffer. It goes up to 200-400% CPU in less then a minute.

Let's add a 1-second delay after the uploading error to avoid this.