### PR TITLE
Enable gzip compression for uploading to clickhouse

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ type = "points"
 table = "graphite"
 threads = 1
 url = "http://localhost:8123/"
+# compress-data enables gzip compression while sending to clickhouse
+compress-data = true
 timeout = "1m0s"
 # save zero value to Timestamp column (for point and posts-reverse tables)
 zero-timestamp = false 

--- a/uploader/config.go
+++ b/uploader/config.go
@@ -17,6 +17,7 @@ type Config struct {
 	URL             string           `toml:"url"`
 	CacheTTL        *config.Duration `toml:"cache-ttl"`
 	IgnoredPatterns []string         `toml:"ignored-patterns,omitempty"` // points, points-reverse
+	CompressData    bool			 `toml:"compress-data"` //compress data while sending to clickhouse
 }
 
 func (cfg *Config) Parse() error {


### PR DESCRIPTION
Hi,

carbon-clickhouse does not compress POST body when sending to clickhouse, even if it can. 

This PR adds support for gzip compression along with an appropriate config switch. We do send metrics to CH across the ocean, and since the network speed sometimes varies a lot, gzipping would allow us to somewhat mitigate the issue by decreasing the volume of data sent by 5x-10x.

This PR does not break default behaviour (default is still uncompressed).

