### PR TITLE
Taggs uploader, ignored-tagged-metrics config section

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,8 @@ cache-ttl = "12h0m0s"
 # timeout = "1m0s"
 # cache-ttl = "12h0m0s"
 # ignored-tagged-metrics = [
-#     "a.b.c.d",
+#     "a.b.c.d",  # all tags (but __name__) will be ignored for metrics like a.b.c.d?tagName1=tagValue1&tagName2=tagValue2...
+#     "*",  # all tags (but __name__) will be ignored for all metrics; this is the only special case with wildcards
 # ]
 
 [udp]

--- a/README.md
+++ b/README.md
@@ -145,6 +145,8 @@ cache-ttl = "12h0m0s"
 # ]
 
 # # Extra table which can be used as index for tagged series
+# # Also, there is an opportunity to avoid writing tags for some metrics.
+# # Example below, ignored-tagged-metrics.
 # [upload.graphite_tagged]
 # type = "tagged"
 # table = "graphite_tagged"
@@ -152,6 +154,9 @@ cache-ttl = "12h0m0s"
 # url = "http://localhost:8123/"
 # timeout = "1m0s"
 # cache-ttl = "12h0m0s"
+# ignored-tagged-metrics = [
+#     "a.b.c.d",
+# ]
 
 [udp]
 listen = ":2003"

--- a/carbon-clickhouse.go
+++ b/carbon-clickhouse.go
@@ -20,7 +20,7 @@ import (
 )
 
 // Version of carbon-clickhouse
-const Version = "0.11.1"
+const Version = "0.11.0"
 
 func httpServe(addr string) (func(), error) {
 	tcpAddr, err := net.ResolveTCPAddr("tcp", addr)

--- a/uploader/config.go
+++ b/uploader/config.go
@@ -7,17 +7,18 @@ import (
 )
 
 type Config struct {
-	Type            string           `toml:"type"`  // points, series, points-reverse, series-reverse
-	TableName       string           `toml:"table"` // keep empty for same as key
-	Timeout         *config.Duration `toml:"timeout"`
-	Date            string           `toml:"date"` // for tree table
-	TreeDate        time.Time        `toml:"-"`
-	ZeroTimestamp   bool             `toml:"zero-timestamp"` // for points, points-reverse tables
-	Threads         int              `toml:"threads"`
-	URL             string           `toml:"url"`
-	CacheTTL        *config.Duration `toml:"cache-ttl"`
-	IgnoredPatterns []string         `toml:"ignored-patterns,omitempty"` // points, points-reverse
-	CompressData    bool			 `toml:"compress-data"` //compress data while sending to clickhouse
+	Type                 string           `toml:"type"`  // points, series, points-reverse, series-reverse
+	TableName            string           `toml:"table"` // keep empty for same as key
+	Timeout              *config.Duration `toml:"timeout"`
+	Date                 string           `toml:"date"` // for tree table
+	TreeDate             time.Time        `toml:"-"`
+	ZeroTimestamp        bool             `toml:"zero-timestamp"` // for points, points-reverse tables
+	Threads              int              `toml:"threads"`
+	URL                  string           `toml:"url"`
+	CacheTTL             *config.Duration `toml:"cache-ttl"`
+	IgnoredPatterns      []string         `toml:"ignored-patterns,omitempty"` // points, points-reverse
+	CompressData         bool             `toml:"compress-data"`              //compress data while sending to clickhouse
+	IgnoredTaggedMetrics []string         `toml:"ignored-tagged-metrics"`     // for tagged table; create only `__name__` tag for these metrics and ignore others
 }
 
 func (cfg *Config) Parse() error {

--- a/uploader/tagged.go
+++ b/uploader/tagged.go
@@ -107,8 +107,8 @@ LineLoop:
 		tagsBuf.WriteString(t)
 
 		// don't upload any other tag but __name__
-		// if the main metric (m.Path) is ignored
-		if !u.ignoredMetrics[m.Path] {
+		// if either main metric (m.Path) or each metric (*) is ignored
+		if !u.ignoredMetrics[m.Path] && !u.ignoredMetrics["*"] {
 			for k, v := range m.Query() {
 				t := fmt.Sprintf("%s=%s", k, v[0])
 				tag1 = append(tag1, t)

--- a/uploader/uploader.go
+++ b/uploader/uploader.go
@@ -38,6 +38,10 @@ func New(path string, name string, config *Config) (Uploader, error) {
 		logger.Warn(fmt.Sprintf("IgnoredPatterns are supported for points and points-reverse only, not for %s", c.Type))
 	}
 
+	if c.Type != "tagged" && len(c.IgnoredTaggedMetrics) > 0 {
+		logger.Warn(fmt.Sprintf("IgnoredTaggedMetrics are supported for tagged only, not for %s", c.Type))
+	}
+
 	var res Uploader
 
 	switch c.Type {


### PR DESCRIPTION
For each metric described in this config section, tags uploader ignores all tags but `__name__`. There is also an opportunity to do this with every metric, using "*".