### PR TITLE
Tagged uploader, fixed ignored-tagged-metrics behavior

### DIFF
--- a/carbon-clickhouse.go
+++ b/carbon-clickhouse.go
@@ -20,7 +20,7 @@ import (
 )
 
 // Version of carbon-clickhouse
-const Version = "0.11.0.custom.2"
+const Version = "0.11.0"
 
 func httpServe(addr string) (func(), error) {
 	tcpAddr, err := net.ResolveTCPAddr("tcp", addr)

--- a/carbon-clickhouse.go
+++ b/carbon-clickhouse.go
@@ -20,7 +20,7 @@ import (
 )
 
 // Version of carbon-clickhouse
-const Version = "0.11.0"
+const Version = "0.11.0.custom"
 
 func httpServe(addr string) (func(), error) {
 	tcpAddr, err := net.ResolveTCPAddr("tcp", addr)

--- a/carbon-clickhouse.go
+++ b/carbon-clickhouse.go
@@ -20,7 +20,7 @@ import (
 )
 
 // Version of carbon-clickhouse
-const Version = "0.11.0.custom"
+const Version = "0.11.0.custom.2"
 
 func httpServe(addr string) (func(), error) {
 	tcpAddr, err := net.ResolveTCPAddr("tcp", addr)

--- a/uploader/tagged.go
+++ b/uploader/tagged.go
@@ -108,11 +108,13 @@ LineLoop:
 
 		// don't upload any other tag but __name__
 		// if either main metric (m.Path) or each metric (*) is ignored
-		if !u.ignoredMetrics[m.Path] && !u.ignoredMetrics["*"] {
-			for k, v := range m.Query() {
-				t := fmt.Sprintf("%s=%s", k, v[0])
+		ignoreAllButName := u.ignoredMetrics[m.Path] || u.ignoredMetrics["*"]
+		for k, v := range m.Query() {
+			t := fmt.Sprintf("%s=%s", k, v[0])
+			tagsBuf.WriteString(t)
+
+			if !ignoreAllButName {
 				tag1 = append(tag1, t)
-				tagsBuf.WriteString(t)
 			}
 		}
 


### PR DESCRIPTION
If metric's path is ignored, we create only 1 record in tags table, where `tag1` column contains `__name__=metricsName` and `tags` column contains all tags.