### PR TITLE
uploader: replace fnv32 with murmur3 in CMap for better perfomance

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,8 +12,10 @@ require (
 	github.com/lomik/og-rek v0.0.0-20170411191824-628eefeb8d80 // indirect
 	github.com/lomik/stop v0.0.0-20161127103810-188e98d969bd // indirect
 	github.com/lomik/zapwriter v0.0.0-20170315193840-d4499a33b592
+	github.com/msaf1980/stringutils v0.0.2-0.20201020141843-69ada32f5dc0
 	github.com/pierrec/lz4 v2.5.2+incompatible
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/spaolacci/murmur3 v1.1.0
 	github.com/stretchr/testify v1.3.0
 	go.uber.org/multierr v1.6.0 // indirect
 	go.uber.org/zap v1.7.1

--- a/go.sum
+++ b/go.sum
@@ -46,6 +46,10 @@ github.com/lomik/stop v0.0.0-20161127103810-188e98d969bd h1:hUNpVzZOYNANa5s8XMBE
 github.com/lomik/stop v0.0.0-20161127103810-188e98d969bd/go.mod h1:3pLqdYIrxHYk+VsfIlrTcBD9J34YkGq8iN9yzJuhrP0=
 github.com/lomik/zapwriter v0.0.0-20170315193840-d4499a33b592 h1:NEjGY17W0lNlYFX9i7GupGjrJojX2Ilhy4XebC+86+w=
 github.com/lomik/zapwriter v0.0.0-20170315193840-d4499a33b592/go.mod h1:8xn4WUTM35HWUh6BGz2NkXFmD2l4D420gb4lL8OPJcg=
+github.com/msaf1980/stringutils v0.0.1 h1:g0EnWEuidjdhYju2brLAOiZAgSONqpJAAYF80uZImv0=
+github.com/msaf1980/stringutils v0.0.1/go.mod h1:PVF+ukHO/yBVWyAOLIeFJT5XyGoI2oR8y2S/8gOjJOw=
+github.com/msaf1980/stringutils v0.0.2-0.20201020141843-69ada32f5dc0 h1:mECAdOf/jCR2l5KiE0QfiW/MxRKyMMQb3hjrX8Q1syk=
+github.com/msaf1980/stringutils v0.0.2-0.20201020141843-69ada32f5dc0/go.mod h1:PVF+ukHO/yBVWyAOLIeFJT5XyGoI2oR8y2S/8gOjJOw=
 github.com/pierrec/lz4 v2.5.2+incompatible h1:WCjObylUIOlKy/+7Abdn34TLIkXiA4UWUMhxq9m9ZXI=
 github.com/pierrec/lz4 v2.5.2+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
@@ -53,6 +57,8 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
+github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=
+github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=

--- a/uploader/cmap.go
+++ b/uploader/cmap.go
@@ -5,6 +5,9 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/msaf1980/stringutils"
+	"github.com/spaolacci/murmur3"
 )
 
 var shardCount = 1024
@@ -66,7 +69,9 @@ func (m CMap) Clear() int {
 // Returns shard under given key
 func (m CMap) GetShard(key string) *CMapShard {
 	// @TODO: remove type casts
-	return m[uint(fnv32(key))%uint(shardCount)]
+	//return m[uint(fnv32(key))%uint(shardCount)]
+	// replace hash function to murmur3 for better perfomance]
+	return m[uint(murmur3.Sum32(stringutils.UnsafeStringBytes(&key)))%uint(shardCount)]
 }
 
 // Retrieves an element from map under given key.

--- a/uploader/cmap_test.go
+++ b/uploader/cmap_test.go
@@ -1,0 +1,30 @@
+package uploader
+
+import (
+	"testing"
+
+	"github.com/msaf1980/stringutils"
+	"github.com/spaolacci/murmur3"
+)
+
+func Benchmark_fnv32(b *testing.B) {
+	s := "asdfghjklqwe.rtyuiopzxc.vbnm1234567890"
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		fnv32(s)
+	}
+}
+
+func Benchmark_murmur32(b *testing.B) {
+	s := "asdfghjklqwe.rtyuiopzxc.vbnm1234567890"
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		murmur3.Sum32(stringutils.UnsafeStringBytes(&s))
+	}
+}

--- a/vendor/github.com/msaf1980/stringutils/.travis.yml
+++ b/vendor/github.com/msaf1980/stringutils/.travis.yml
@@ -1,0 +1,5 @@
+language: go
+
+go:
+  - 1.14
+  - tip

--- a/vendor/github.com/msaf1980/stringutils/README.md
+++ b/vendor/github.com/msaf1980/stringutils/README.md
@@ -1,0 +1,11 @@
+# stringutils
+
+Some string utils
+
+`UnsafeString([]byte) string` return unsafe string from bytes slice indirectly (without allocation)
+`UnsafeStringFromPtr(*byte, length) string` return unsafe string from bytes slice pointer indirectly (without allocation)
+`UnsafeStringBytes(*string) []bytes` return unsafe string bytes indirectly (without allocation)
+
+`Split2(s string, sep string) (string, string, int)`  Split2 return the split string results (without memory allocations)
+
+`Builder` very simular to strings.Builder, but has better perfomance (at golang 1.14).

--- a/vendor/github.com/msaf1980/stringutils/split.go
+++ b/vendor/github.com/msaf1980/stringutils/split.go
@@ -1,0 +1,23 @@
+package stringutils
+
+import "strings"
+
+var empthy = ""
+
+// Split2 return the split string results (without memory allocations)
+//   If sep string not found: 's' '' 1
+//   If s or sep string is empthy: 's' '' 1
+//   In other cases: 's0' 's2' 2
+func Split2(s string, sep string) (string, string, int) {
+	if sep == "" {
+		return s, empthy, 1
+	}
+
+	if pos := strings.Index(s, sep); pos == -1 {
+		return s, empthy, 1
+	} else if pos == len(s)-1 {
+		return s[0:pos], empthy, 2
+	} else {
+		return s[0:pos], s[pos+1:], 2
+	}
+}

--- a/vendor/github.com/msaf1980/stringutils/stringbuilder.go
+++ b/vendor/github.com/msaf1980/stringutils/stringbuilder.go
@@ -1,0 +1,132 @@
+package stringutils
+
+import (
+	"unicode/utf8"
+)
+
+// A Builder is used to efficiently build a string using Write methods (with better perfomance than strings.Builder).
+// It minimizes memory copying. The zero value is ready to use.
+// Do not copy a non-zero Builder.
+type Builder struct {
+	data   []byte
+	length int
+}
+
+// grow scale factor for needed resize
+const scaleFactor = 2
+
+// Len returns the number of accumulated bytes; b.Len() == len(b.String()).
+func (sb *Builder) Len() int {
+	return sb.length
+}
+
+// Cap returns the capacity of the builder's underlying byte slice. It is the
+// total space allocated for the string being built and includes any bytes
+// already written.
+func (sb *Builder) Cap() int {
+	return len(sb.data)
+}
+
+// Bytes returns the accumulated bytes.
+func (sb *Builder) Bytes() []byte {
+	return sb.data[0:sb.length]
+}
+
+// String returns the accumulated string.
+func (sb *Builder) String() string {
+	if sb.length == 0 {
+		return ""
+	}
+	return UnsafeStringFromPtr(&sb.data[0], sb.length)
+}
+
+// Grow grows b's capacity, if necessary, to guarantee space for
+// another n bytes. After Grow(n), at least n bytes can be written to b
+// without another allocation.
+func (sb *Builder) Grow(capacity int) {
+	if capacity > sb.Cap() {
+		b := make([]byte, capacity)
+		copy(b, sb.data[0:sb.length])
+		sb.data = b
+	}
+}
+
+// Reset resets the Builder to be empty.
+func (sb *Builder) Reset() {
+	if sb.length > 0 {
+		sb.length = 0
+	}
+}
+
+// Release resets the Builder to be empty and free buffer
+func (sb *Builder) Release() {
+	if cap(sb.data) > 0 {
+		sb.data = nil
+	}
+	sb.Reset()
+}
+
+// Write appends the contents of p to b's buffer.
+func (sb *Builder) Write(bytes []byte) {
+	if len(bytes) == 0 {
+		return
+	}
+	newlen := sb.length + len(bytes)
+	if newlen > cap(sb.data) {
+		scaled := sb.length * scaleFactor
+		if newlen > scaled {
+			sb.Grow(newlen)
+		} else {
+			sb.Grow(scaled)
+		}
+	}
+	copy(sb.data[sb.length:], bytes)
+	sb.length += len(bytes)
+}
+
+// WriteString appends the contents of s to b's buffer.
+func (sb *Builder) WriteString(s string) {
+	if len(s) == 0 {
+		return
+	}
+	newlen := sb.length + len(s)
+	if newlen > cap(sb.data) {
+		scaled := sb.length * scaleFactor
+		if newlen > scaled {
+			sb.Grow(newlen)
+		} else {
+			sb.Grow(scaled)
+		}
+	}
+	copy(sb.data[sb.length:], s)
+	sb.length += len(s)
+}
+
+// WriteByte appends the byte c to b's buffer.
+func (sb *Builder) WriteByte(c byte) {
+	if sb.length == cap(sb.data) {
+		if sb.length == 0 {
+			sb.Grow(2 * scaleFactor)
+		} else {
+			sb.Grow(sb.length * scaleFactor)
+		}
+	}
+	sb.data[sb.length] = c
+	sb.length++
+}
+
+// WriteRune appends the UTF-8 encoding of Unicode code point r to b's buffer.
+func (sb *Builder) WriteRune(r rune) {
+	if r < utf8.RuneSelf {
+		sb.WriteByte(byte(r))
+	} else {
+		if sb.length+utf8.UTFMax > cap(sb.data) {
+			if sb.length > 2*utf8.UTFMax {
+				sb.Grow(sb.length * scaleFactor)
+			} else {
+				sb.Grow(sb.length + utf8.UTFMax*scaleFactor)
+			}
+		}
+		sb.length += utf8.EncodeRune(sb.data[sb.length:sb.length+utf8.UTFMax], r)
+	}
+}

--- a/vendor/github.com/msaf1980/stringutils/unsafe.go
+++ b/vendor/github.com/msaf1980/stringutils/unsafe.go
@@ -1,0 +1,25 @@
+package stringutils
+
+import (
+	"reflect"
+	"unsafe"
+)
+
+// UnsafeString returns the string under byte buffer
+func UnsafeString(b []byte) string {
+	return *(*string)(unsafe.Pointer(&b))
+}
+
+// UnsafeStringFromPtr returns the string with specific length under byte buffer
+func UnsafeStringFromPtr(ptr *byte, length int) (s string) {
+	str := (*reflect.StringHeader)(unsafe.Pointer(&s))
+	str.Data = uintptr(unsafe.Pointer(ptr))
+	str.Len = length
+
+	return s
+}
+
+// UnsafeStringBytes returns the string bytes
+func UnsafeStringBytes(s *string) []byte {
+	return *(*[]byte)(unsafe.Pointer((*reflect.SliceHeader)(unsafe.Pointer(s))))
+}

--- a/vendor/github.com/spaolacci/murmur3/.gitignore
+++ b/vendor/github.com/spaolacci/murmur3/.gitignore
@@ -1,0 +1,22 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe

--- a/vendor/github.com/spaolacci/murmur3/.travis.yml
+++ b/vendor/github.com/spaolacci/murmur3/.travis.yml
@@ -1,0 +1,7 @@
+language: go
+
+go:
+    - 1.x
+    - master
+
+script: go test

--- a/vendor/github.com/spaolacci/murmur3/LICENSE
+++ b/vendor/github.com/spaolacci/murmur3/LICENSE
@@ -1,0 +1,24 @@
+Copyright 2013, Sébastien Paolacci.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the library nor the
+      names of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/github.com/spaolacci/murmur3/README.md
+++ b/vendor/github.com/spaolacci/murmur3/README.md
@@ -1,0 +1,86 @@
+murmur3
+=======
+
+[![Build Status](https://travis-ci.org/spaolacci/murmur3.svg?branch=master)](https://travis-ci.org/spaolacci/murmur3)
+
+Native Go implementation of Austin Appleby's third MurmurHash revision (aka
+MurmurHash3).
+
+Reference algorithm has been slightly hacked as to support the streaming mode
+required by Go's standard [Hash interface](http://golang.org/pkg/hash/#Hash).
+
+
+Benchmarks
+----------
+
+Go tip as of 2014-06-12 (i.e almost go1.3), core i7 @ 3.4 Ghz. All runs
+include hasher instantiation and sequence finalization.
+
+<pre>
+
+Benchmark32_1        500000000     7.69 ns/op      130.00 MB/s
+Benchmark32_2        200000000     8.83 ns/op      226.42 MB/s
+Benchmark32_4        500000000     7.99 ns/op      500.39 MB/s
+Benchmark32_8        200000000     9.47 ns/op      844.69 MB/s
+Benchmark32_16       100000000     12.1 ns/op     1321.61 MB/s
+Benchmark32_32       100000000     18.3 ns/op     1743.93 MB/s
+Benchmark32_64        50000000     30.9 ns/op     2071.64 MB/s
+Benchmark32_128       50000000     57.6 ns/op     2222.96 MB/s
+Benchmark32_256       20000000      116 ns/op     2188.60 MB/s
+Benchmark32_512       10000000      226 ns/op     2260.59 MB/s
+Benchmark32_1024       5000000      452 ns/op     2263.73 MB/s
+Benchmark32_2048       2000000      891 ns/op     2296.02 MB/s
+Benchmark32_4096       1000000     1787 ns/op     2290.92 MB/s
+Benchmark32_8192        500000     3593 ns/op     2279.68 MB/s
+Benchmark128_1       100000000     26.1 ns/op       38.33 MB/s
+Benchmark128_2       100000000     29.0 ns/op       69.07 MB/s
+Benchmark128_4        50000000     29.8 ns/op      134.17 MB/s
+Benchmark128_8        50000000     31.6 ns/op      252.86 MB/s
+Benchmark128_16      100000000     26.5 ns/op      603.42 MB/s
+Benchmark128_32      100000000     28.6 ns/op     1117.15 MB/s
+Benchmark128_64       50000000     35.5 ns/op     1800.97 MB/s
+Benchmark128_128      50000000     50.9 ns/op     2515.50 MB/s
+Benchmark128_256      20000000     76.9 ns/op     3330.11 MB/s
+Benchmark128_512      20000000      135 ns/op     3769.09 MB/s
+Benchmark128_1024     10000000      250 ns/op     4094.38 MB/s
+Benchmark128_2048      5000000      477 ns/op     4290.75 MB/s
+Benchmark128_4096      2000000      940 ns/op     4353.29 MB/s
+Benchmark128_8192      1000000     1838 ns/op     4455.47 MB/s
+
+</pre>
+
+
+<pre>
+
+benchmark              Go1.0 MB/s    Go1.1 MB/s  speedup    Go1.2 MB/s  speedup    Go1.3 MB/s  speedup
+Benchmark32_1               98.90        118.59    1.20x        114.79    0.97x        130.00    1.13x
+Benchmark32_2              168.04        213.31    1.27x        210.65    0.99x        226.42    1.07x
+Benchmark32_4              414.01        494.19    1.19x        490.29    0.99x        500.39    1.02x
+Benchmark32_8              662.19        836.09    1.26x        836.46    1.00x        844.69    1.01x
+Benchmark32_16             917.46       1304.62    1.42x       1297.63    0.99x       1321.61    1.02x
+Benchmark32_32            1141.93       1737.54    1.52x       1728.24    0.99x       1743.93    1.01x
+Benchmark32_64            1289.47       2039.51    1.58x       2038.20    1.00x       2071.64    1.02x
+Benchmark32_128           1299.23       2097.63    1.61x       2177.13    1.04x       2222.96    1.02x
+Benchmark32_256           1369.90       2202.34    1.61x       2213.15    1.00x       2188.60    0.99x
+Benchmark32_512           1399.56       2255.72    1.61x       2264.49    1.00x       2260.59    1.00x
+Benchmark32_1024          1410.90       2285.82    1.62x       2270.99    0.99x       2263.73    1.00x
+Benchmark32_2048          1422.14       2297.62    1.62x       2269.59    0.99x       2296.02    1.01x
+Benchmark32_4096          1420.53       2307.81    1.62x       2273.43    0.99x       2290.92    1.01x
+Benchmark32_8192          1424.79       2312.87    1.62x       2286.07    0.99x       2279.68    1.00x
+Benchmark128_1               8.32         30.15    3.62x         30.84    1.02x         38.33    1.24x
+Benchmark128_2              16.38         59.72    3.65x         59.37    0.99x         69.07    1.16x
+Benchmark128_4              32.26        112.96    3.50x        114.24    1.01x        134.17    1.17x
+Benchmark128_8              62.68        217.88    3.48x        218.18    1.00x        252.86    1.16x
+Benchmark128_16            128.47        451.57    3.51x        474.65    1.05x        603.42    1.27x
+Benchmark128_32            246.18        910.42    3.70x        871.06    0.96x       1117.15    1.28x
+Benchmark128_64            449.05       1477.64    3.29x       1449.24    0.98x       1800.97    1.24x
+Benchmark128_128           762.61       2222.42    2.91x       2217.30    1.00x       2515.50    1.13x
+Benchmark128_256          1179.92       3005.46    2.55x       2931.55    0.98x       3330.11    1.14x
+Benchmark128_512          1616.51       3590.75    2.22x       3592.08    1.00x       3769.09    1.05x
+Benchmark128_1024         1964.36       3979.67    2.03x       4034.01    1.01x       4094.38    1.01x
+Benchmark128_2048         2225.07       4156.93    1.87x       4244.17    1.02x       4290.75    1.01x
+Benchmark128_4096         2360.15       4299.09    1.82x       4392.35    1.02x       4353.29    0.99x
+Benchmark128_8192         2411.50       4356.84    1.81x       4480.68    1.03x       4455.47    0.99x
+
+</pre>
+

--- a/vendor/github.com/spaolacci/murmur3/murmur.go
+++ b/vendor/github.com/spaolacci/murmur3/murmur.go
@@ -1,0 +1,64 @@
+// Copyright 2013, Sébastien Paolacci. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+/*
+Package murmur3 implements Austin Appleby's non-cryptographic MurmurHash3.
+
+ Reference implementation:
+    http://code.google.com/p/smhasher/wiki/MurmurHash3
+
+ History, characteristics and (legacy) perfs:
+    https://sites.google.com/site/murmurhash/
+    https://sites.google.com/site/murmurhash/statistics
+*/
+package murmur3
+
+type bmixer interface {
+	bmix(p []byte) (tail []byte)
+	Size() (n int)
+	reset()
+}
+
+type digest struct {
+	clen int      // Digested input cumulative length.
+	tail []byte   // 0 to Size()-1 bytes view of `buf'.
+	buf  [16]byte // Expected (but not required) to be Size() large.
+	seed uint32   // Seed for initializing the hash.
+	bmixer
+}
+
+func (d *digest) BlockSize() int { return 1 }
+
+func (d *digest) Write(p []byte) (n int, err error) {
+	n = len(p)
+	d.clen += n
+
+	if len(d.tail) > 0 {
+		// Stick back pending bytes.
+		nfree := d.Size() - len(d.tail) // nfree ∈ [1, d.Size()-1].
+		if nfree < len(p) {
+			// One full block can be formed.
+			block := append(d.tail, p[:nfree]...)
+			p = p[nfree:]
+			_ = d.bmix(block) // No tail.
+		} else {
+			// Tail's buf is large enough to prevent reallocs.
+			p = append(d.tail, p...)
+		}
+	}
+
+	d.tail = d.bmix(p)
+
+	// Keep own copy of the 0 to Size()-1 pending bytes.
+	nn := copy(d.buf[:], d.tail)
+	d.tail = d.buf[:nn]
+
+	return n, nil
+}
+
+func (d *digest) Reset() {
+	d.clen = 0
+	d.tail = nil
+	d.bmixer.reset()
+}

--- a/vendor/github.com/spaolacci/murmur3/murmur128.go
+++ b/vendor/github.com/spaolacci/murmur3/murmur128.go
@@ -1,0 +1,203 @@
+package murmur3
+
+import (
+	//"encoding/binary"
+	"hash"
+	"unsafe"
+)
+
+const (
+	c1_128 = 0x87c37b91114253d5
+	c2_128 = 0x4cf5ad432745937f
+)
+
+// Make sure interfaces are correctly implemented.
+var (
+	_ hash.Hash = new(digest128)
+	_ Hash128   = new(digest128)
+	_ bmixer    = new(digest128)
+)
+
+// Hash128 represents a 128-bit hasher
+// Hack: the standard api doesn't define any Hash128 interface.
+type Hash128 interface {
+	hash.Hash
+	Sum128() (uint64, uint64)
+}
+
+// digest128 represents a partial evaluation of a 128 bites hash.
+type digest128 struct {
+	digest
+	h1 uint64 // Unfinalized running hash part 1.
+	h2 uint64 // Unfinalized running hash part 2.
+}
+
+// New128 returns a 128-bit hasher
+func New128() Hash128 { return New128WithSeed(0) }
+
+// New128WithSeed returns a 128-bit hasher set with explicit seed value
+func New128WithSeed(seed uint32) Hash128 {
+	d := new(digest128)
+	d.seed = seed
+	d.bmixer = d
+	d.Reset()
+	return d
+}
+
+func (d *digest128) Size() int { return 16 }
+
+func (d *digest128) reset() { d.h1, d.h2 = uint64(d.seed), uint64(d.seed) }
+
+func (d *digest128) Sum(b []byte) []byte {
+	h1, h2 := d.Sum128()
+	return append(b,
+		byte(h1>>56), byte(h1>>48), byte(h1>>40), byte(h1>>32),
+		byte(h1>>24), byte(h1>>16), byte(h1>>8), byte(h1),
+
+		byte(h2>>56), byte(h2>>48), byte(h2>>40), byte(h2>>32),
+		byte(h2>>24), byte(h2>>16), byte(h2>>8), byte(h2),
+	)
+}
+
+func (d *digest128) bmix(p []byte) (tail []byte) {
+	h1, h2 := d.h1, d.h2
+
+	nblocks := len(p) / 16
+	for i := 0; i < nblocks; i++ {
+		t := (*[2]uint64)(unsafe.Pointer(&p[i*16]))
+		k1, k2 := t[0], t[1]
+
+		k1 *= c1_128
+		k1 = (k1 << 31) | (k1 >> 33) // rotl64(k1, 31)
+		k1 *= c2_128
+		h1 ^= k1
+
+		h1 = (h1 << 27) | (h1 >> 37) // rotl64(h1, 27)
+		h1 += h2
+		h1 = h1*5 + 0x52dce729
+
+		k2 *= c2_128
+		k2 = (k2 << 33) | (k2 >> 31) // rotl64(k2, 33)
+		k2 *= c1_128
+		h2 ^= k2
+
+		h2 = (h2 << 31) | (h2 >> 33) // rotl64(h2, 31)
+		h2 += h1
+		h2 = h2*5 + 0x38495ab5
+	}
+	d.h1, d.h2 = h1, h2
+	return p[nblocks*d.Size():]
+}
+
+func (d *digest128) Sum128() (h1, h2 uint64) {
+
+	h1, h2 = d.h1, d.h2
+
+	var k1, k2 uint64
+	switch len(d.tail) & 15 {
+	case 15:
+		k2 ^= uint64(d.tail[14]) << 48
+		fallthrough
+	case 14:
+		k2 ^= uint64(d.tail[13]) << 40
+		fallthrough
+	case 13:
+		k2 ^= uint64(d.tail[12]) << 32
+		fallthrough
+	case 12:
+		k2 ^= uint64(d.tail[11]) << 24
+		fallthrough
+	case 11:
+		k2 ^= uint64(d.tail[10]) << 16
+		fallthrough
+	case 10:
+		k2 ^= uint64(d.tail[9]) << 8
+		fallthrough
+	case 9:
+		k2 ^= uint64(d.tail[8]) << 0
+
+		k2 *= c2_128
+		k2 = (k2 << 33) | (k2 >> 31) // rotl64(k2, 33)
+		k2 *= c1_128
+		h2 ^= k2
+
+		fallthrough
+
+	case 8:
+		k1 ^= uint64(d.tail[7]) << 56
+		fallthrough
+	case 7:
+		k1 ^= uint64(d.tail[6]) << 48
+		fallthrough
+	case 6:
+		k1 ^= uint64(d.tail[5]) << 40
+		fallthrough
+	case 5:
+		k1 ^= uint64(d.tail[4]) << 32
+		fallthrough
+	case 4:
+		k1 ^= uint64(d.tail[3]) << 24
+		fallthrough
+	case 3:
+		k1 ^= uint64(d.tail[2]) << 16
+		fallthrough
+	case 2:
+		k1 ^= uint64(d.tail[1]) << 8
+		fallthrough
+	case 1:
+		k1 ^= uint64(d.tail[0]) << 0
+		k1 *= c1_128
+		k1 = (k1 << 31) | (k1 >> 33) // rotl64(k1, 31)
+		k1 *= c2_128
+		h1 ^= k1
+	}
+
+	h1 ^= uint64(d.clen)
+	h2 ^= uint64(d.clen)
+
+	h1 += h2
+	h2 += h1
+
+	h1 = fmix64(h1)
+	h2 = fmix64(h2)
+
+	h1 += h2
+	h2 += h1
+
+	return h1, h2
+}
+
+func fmix64(k uint64) uint64 {
+	k ^= k >> 33
+	k *= 0xff51afd7ed558ccd
+	k ^= k >> 33
+	k *= 0xc4ceb9fe1a85ec53
+	k ^= k >> 33
+	return k
+}
+
+/*
+func rotl64(x uint64, r byte) uint64 {
+	return (x << r) | (x >> (64 - r))
+}
+*/
+
+// Sum128 returns the MurmurHash3 sum of data. It is equivalent to the
+// following sequence (without the extra burden and the extra allocation):
+//     hasher := New128()
+//     hasher.Write(data)
+//     return hasher.Sum128()
+func Sum128(data []byte) (h1 uint64, h2 uint64) { return Sum128WithSeed(data, 0) }
+
+// Sum128WithSeed returns the MurmurHash3 sum of data. It is equivalent to the
+// following sequence (without the extra burden and the extra allocation):
+//     hasher := New128WithSeed(seed)
+//     hasher.Write(data)
+//     return hasher.Sum128()
+func Sum128WithSeed(data []byte, seed uint32) (h1 uint64, h2 uint64) {
+	d := &digest128{h1: uint64(seed), h2: uint64(seed)}
+	d.seed = seed
+	d.tail = d.bmix(data)
+	d.clen = len(data)
+	return d.Sum128()
+}

--- a/vendor/github.com/spaolacci/murmur3/murmur32.go
+++ b/vendor/github.com/spaolacci/murmur3/murmur32.go
@@ -1,0 +1,167 @@
+package murmur3
+
+// http://code.google.com/p/guava-libraries/source/browse/guava/src/com/google/common/hash/Murmur3_32HashFunction.java
+
+import (
+	"hash"
+	"unsafe"
+)
+
+// Make sure interfaces are correctly implemented.
+var (
+	_ hash.Hash   = new(digest32)
+	_ hash.Hash32 = new(digest32)
+	_ bmixer      = new(digest32)
+)
+
+const (
+	c1_32 uint32 = 0xcc9e2d51
+	c2_32 uint32 = 0x1b873593
+)
+
+// digest32 represents a partial evaluation of a 32 bites hash.
+type digest32 struct {
+	digest
+	h1 uint32 // Unfinalized running hash.
+}
+
+// New32 returns new 32-bit hasher
+func New32() hash.Hash32 { return New32WithSeed(0) }
+
+// New32WithSeed returns new 32-bit hasher set with explicit seed value
+func New32WithSeed(seed uint32) hash.Hash32 {
+	d := new(digest32)
+	d.seed = seed
+	d.bmixer = d
+	d.Reset()
+	return d
+}
+
+func (d *digest32) Size() int { return 4 }
+
+func (d *digest32) reset() { d.h1 = d.seed }
+
+func (d *digest32) Sum(b []byte) []byte {
+	h := d.Sum32()
+	return append(b, byte(h>>24), byte(h>>16), byte(h>>8), byte(h))
+}
+
+// Digest as many blocks as possible.
+func (d *digest32) bmix(p []byte) (tail []byte) {
+	h1 := d.h1
+
+	nblocks := len(p) / 4
+	for i := 0; i < nblocks; i++ {
+		k1 := *(*uint32)(unsafe.Pointer(&p[i*4]))
+
+		k1 *= c1_32
+		k1 = (k1 << 15) | (k1 >> 17) // rotl32(k1, 15)
+		k1 *= c2_32
+
+		h1 ^= k1
+		h1 = (h1 << 13) | (h1 >> 19) // rotl32(h1, 13)
+		h1 = h1*4 + h1 + 0xe6546b64
+	}
+	d.h1 = h1
+	return p[nblocks*d.Size():]
+}
+
+func (d *digest32) Sum32() (h1 uint32) {
+
+	h1 = d.h1
+
+	var k1 uint32
+	switch len(d.tail) & 3 {
+	case 3:
+		k1 ^= uint32(d.tail[2]) << 16
+		fallthrough
+	case 2:
+		k1 ^= uint32(d.tail[1]) << 8
+		fallthrough
+	case 1:
+		k1 ^= uint32(d.tail[0])
+		k1 *= c1_32
+		k1 = (k1 << 15) | (k1 >> 17) // rotl32(k1, 15)
+		k1 *= c2_32
+		h1 ^= k1
+	}
+
+	h1 ^= uint32(d.clen)
+
+	h1 ^= h1 >> 16
+	h1 *= 0x85ebca6b
+	h1 ^= h1 >> 13
+	h1 *= 0xc2b2ae35
+	h1 ^= h1 >> 16
+
+	return h1
+}
+
+/*
+func rotl32(x uint32, r byte) uint32 {
+	return (x << r) | (x >> (32 - r))
+}
+*/
+
+// Sum32 returns the MurmurHash3 sum of data. It is equivalent to the
+// following sequence (without the extra burden and the extra allocation):
+//     hasher := New32()
+//     hasher.Write(data)
+//     return hasher.Sum32()
+func Sum32(data []byte) uint32 { return Sum32WithSeed(data, 0) }
+
+// Sum32WithSeed returns the MurmurHash3 sum of data. It is equivalent to the
+// following sequence (without the extra burden and the extra allocation):
+//     hasher := New32WithSeed(seed)
+//     hasher.Write(data)
+//     return hasher.Sum32()
+func Sum32WithSeed(data []byte, seed uint32) uint32 {
+
+	h1 := seed
+
+	nblocks := len(data) / 4
+	var p uintptr
+	if len(data) > 0 {
+		p = uintptr(unsafe.Pointer(&data[0]))
+	}
+	p1 := p + uintptr(4*nblocks)
+	for ; p < p1; p += 4 {
+		k1 := *(*uint32)(unsafe.Pointer(p))
+
+		k1 *= c1_32
+		k1 = (k1 << 15) | (k1 >> 17) // rotl32(k1, 15)
+		k1 *= c2_32
+
+		h1 ^= k1
+		h1 = (h1 << 13) | (h1 >> 19) // rotl32(h1, 13)
+		h1 = h1*4 + h1 + 0xe6546b64
+	}
+
+	tail := data[nblocks*4:]
+
+	var k1 uint32
+	switch len(tail) & 3 {
+	case 3:
+		k1 ^= uint32(tail[2]) << 16
+		fallthrough
+	case 2:
+		k1 ^= uint32(tail[1]) << 8
+		fallthrough
+	case 1:
+		k1 ^= uint32(tail[0])
+		k1 *= c1_32
+		k1 = (k1 << 15) | (k1 >> 17) // rotl32(k1, 15)
+		k1 *= c2_32
+		h1 ^= k1
+	}
+
+	h1 ^= uint32(len(data))
+
+	h1 ^= h1 >> 16
+	h1 *= 0x85ebca6b
+	h1 ^= h1 >> 13
+	h1 *= 0xc2b2ae35
+	h1 ^= h1 >> 16
+
+	return h1
+}

--- a/vendor/github.com/spaolacci/murmur3/murmur64.go
+++ b/vendor/github.com/spaolacci/murmur3/murmur64.go
@@ -1,0 +1,57 @@
+package murmur3
+
+import (
+	"hash"
+)
+
+// Make sure interfaces are correctly implemented.
+var (
+	_ hash.Hash   = new(digest64)
+	_ hash.Hash64 = new(digest64)
+	_ bmixer      = new(digest64)
+)
+
+// digest64 is half a digest128.
+type digest64 digest128
+
+// New64 returns a 64-bit hasher
+func New64() hash.Hash64 { return New64WithSeed(0) }
+
+// New64WithSeed returns a 64-bit hasher set with explicit seed value
+func New64WithSeed(seed uint32) hash.Hash64 {
+	d := (*digest64)(New128WithSeed(seed).(*digest128))
+	return d
+}
+
+func (d *digest64) Sum(b []byte) []byte {
+	h1 := d.Sum64()
+	return append(b,
+		byte(h1>>56), byte(h1>>48), byte(h1>>40), byte(h1>>32),
+		byte(h1>>24), byte(h1>>16), byte(h1>>8), byte(h1))
+}
+
+func (d *digest64) Sum64() uint64 {
+	h1, _ := (*digest128)(d).Sum128()
+	return h1
+}
+
+// Sum64 returns the MurmurHash3 sum of data. It is equivalent to the
+// following sequence (without the extra burden and the extra allocation):
+//     hasher := New64()
+//     hasher.Write(data)
+//     return hasher.Sum64()
+func Sum64(data []byte) uint64 { return Sum64WithSeed(data, 0) }
+
+// Sum64WithSeed returns the MurmurHash3 sum of data. It is equivalent to the
+// following sequence (without the extra burden and the extra allocation):
+//     hasher := New64WithSeed(seed)
+//     hasher.Write(data)
+//     return hasher.Sum64()
+func Sum64WithSeed(data []byte, seed uint32) uint64 {
+	d := &digest128{h1: uint64(seed), h2: uint64(seed)}
+	d.seed = seed
+	d.tail = d.bmix(data)
+	d.clen = len(data)
+	h1, _ := d.Sum128()
+	return h1
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -35,6 +35,9 @@ github.com/lomik/stop
 # github.com/lomik/zapwriter v0.0.0-20170315193840-d4499a33b592
 ## explicit
 github.com/lomik/zapwriter
+# github.com/msaf1980/stringutils v0.0.2-0.20201020141843-69ada32f5dc0
+## explicit
+github.com/msaf1980/stringutils
 # github.com/pierrec/lz4 v2.5.2+incompatible
 ## explicit
 github.com/pierrec/lz4
@@ -43,6 +46,9 @@ github.com/pierrec/lz4/internal/xxh32
 ## explicit
 # github.com/pmezard/go-difflib v1.0.0
 github.com/pmezard/go-difflib/difflib
+# github.com/spaolacci/murmur3 v1.1.0
+## explicit
+github.com/spaolacci/murmur3
 # github.com/stretchr/testify v1.3.0
 ## explicit
 github.com/stretchr/testify/assert


### PR DESCRIPTION
Replace fnv32 with murmur3 hash function with better throughput.

```
$ go test -benchmem -run=^$ github.com/lomik/carbon-clickhouse/uploader -bench Benchmark
goos: linux
goarch: amd64
pkg: github.com/lomik/carbon-clickhouse/uploader
Benchmark_fnv32-6      	43323050	        28.0 ns/op	       0 B/op	       0 allocs/op
Benchmark_murmur32-6   	78771030	        13.6 ns/op	       0 B/op	       0 allocs/op
```