### PR TITLE
Uploader allocations

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/lomik/og-rek v0.0.0-20170411191824-628eefeb8d80 // indirect
 	github.com/lomik/stop v0.0.0-20161127103810-188e98d969bd // indirect
 	github.com/lomik/zapwriter v0.0.0-20170315193840-d4499a33b592
+	github.com/msaf1980/stringutils v0.0.2-0.20201020141843-69ada32f5dc0
 	github.com/pierrec/lz4 v2.5.2+incompatible
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/stretchr/testify v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -46,6 +46,8 @@ github.com/lomik/stop v0.0.0-20161127103810-188e98d969bd h1:hUNpVzZOYNANa5s8XMBE
 github.com/lomik/stop v0.0.0-20161127103810-188e98d969bd/go.mod h1:3pLqdYIrxHYk+VsfIlrTcBD9J34YkGq8iN9yzJuhrP0=
 github.com/lomik/zapwriter v0.0.0-20170315193840-d4499a33b592 h1:NEjGY17W0lNlYFX9i7GupGjrJojX2Ilhy4XebC+86+w=
 github.com/lomik/zapwriter v0.0.0-20170315193840-d4499a33b592/go.mod h1:8xn4WUTM35HWUh6BGz2NkXFmD2l4D420gb4lL8OPJcg=
+github.com/msaf1980/stringutils v0.0.2-0.20201020141843-69ada32f5dc0 h1:mECAdOf/jCR2l5KiE0QfiW/MxRKyMMQb3hjrX8Q1syk=
+github.com/msaf1980/stringutils v0.0.2-0.20201020141843-69ada32f5dc0/go.mod h1:PVF+ukHO/yBVWyAOLIeFJT5XyGoI2oR8y2S/8gOjJOw=
 github.com/pierrec/lz4 v2.5.2+incompatible h1:WCjObylUIOlKy/+7Abdn34TLIkXiA4UWUMhxq9m9ZXI=
 github.com/pierrec/lz4 v2.5.2+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/uploader/index.go
+++ b/uploader/index.go
@@ -2,8 +2,8 @@ package uploader
 
 import (
 	"bytes"
-	"fmt"
 	"io"
+	"strconv"
 	"time"
 
 	"github.com/lomik/carbon-clickhouse/helper/RowBinary"
@@ -65,7 +65,7 @@ LineLoop:
 			continue
 		}
 
-		key := fmt.Sprintf("%d:%s", reader.Days(), unsafeString(name))
+		key := strconv.Itoa(int(reader.Days())) + ":" + unsafeString(name)
 
 		if u.existsCache.Exists(key) {
 			continue LineLoop

--- a/uploader/series.go
+++ b/uploader/series.go
@@ -2,8 +2,8 @@ package uploader
 
 import (
 	"bytes"
-	"fmt"
 	"io"
+	"strconv"
 	"time"
 
 	"github.com/lomik/carbon-clickhouse/helper/RowBinary"
@@ -54,7 +54,7 @@ LineLoop:
 			continue
 		}
 
-		key := fmt.Sprintf("%d:%s", reader.Days(), unsafeString(name))
+		key := strconv.Itoa(int(reader.Days())) + ":" + unsafeString(name)
 
 		if u.existsCache.Exists(key) {
 			continue LineLoop

--- a/uploader/tagged.go
+++ b/uploader/tagged.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 
@@ -82,7 +83,7 @@ LineLoop:
 			continue
 		}
 
-		key := fmt.Sprintf("%d:%s", reader.Days(), unsafeString(name))
+		key := strconv.Itoa(int(reader.Days())) + ":" + unsafeString(name)
 
 		if u.existsCache.Exists(key) {
 			continue LineLoop

--- a/uploader/tagged.go
+++ b/uploader/tagged.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/lomik/carbon-clickhouse/helper/RowBinary"
+	"github.com/msaf1980/stringutils"
 )
 
 type Tagged struct {
@@ -49,6 +50,18 @@ func urlParse(rawurl string) (*url.URL, error) {
 	return m, err
 }
 
+// don't unescape special symbols
+// escape also not needed (all is done in receiver/plain.go, Base.PlainParseLine)
+func tagsParse(path string) (string, []string, error) {
+	name, args, n := stringutils.Split2(path, "?")
+	if n == 1 || args == "" {
+		return name, nil, fmt.Errorf("incomplete tags in '%s'", path)
+	}
+	name = "__name__=" + name
+	tags := strings.Split(args, "&")
+	return name, tags, nil
+}
+
 func (u *Tagged) parseFile(filename string, out io.Writer) (uint64, map[string]bool, error) {
 	var reader *RowBinary.Reader
 	var err error
@@ -69,8 +82,6 @@ func (u *Tagged) parseFile(filename string, out io.Writer) (uint64, map[string]b
 	defer wb.Release()
 	defer tagsBuf.Release()
 
-	tag1 := make([]string, 0)
-
 LineLoop:
 	for {
 		name, err := reader.ReadRecord()
@@ -83,7 +94,8 @@ LineLoop:
 			continue
 		}
 
-		key := strconv.Itoa(int(reader.Days())) + ":" + unsafeString(name)
+		day := reader.Days()
+		key := strconv.Itoa(int(day)) + ":" + unsafeString(name)
 
 		if u.existsCache.Exists(key) {
 			continue LineLoop
@@ -94,7 +106,7 @@ LineLoop:
 		}
 		n++
 
-		m, err := urlParse(unsafeString(name))
+		mname, tags, err := tagsParse(unsafeString(name))
 		if err != nil {
 			continue
 		}
@@ -103,33 +115,36 @@ LineLoop:
 
 		wb.Reset()
 		tagsBuf.Reset()
-		tag1 = tag1[:0]
 
-		t := fmt.Sprintf("__name__=%s", m.Path)
-		tag1 = append(tag1, t)
-		tagsBuf.WriteString(t)
+		tagsBuf.WriteString(mname)
 
 		// don't upload any other tag but __name__
 		// if either main metric (m.Path) or each metric (*) is ignored
-		ignoreAllButName := u.ignoredMetrics[m.Path] || u.ignoredMetrics["*"]
+		ignoreAllButName := u.ignoredMetrics[mname] || u.ignoredMetrics["*"]
 		tagsWritten := 1
-		for k, v := range m.Query() {
-			t := fmt.Sprintf("%s=%s", k, v[0])
-			tagsBuf.WriteString(t)
-			tagsWritten++
-
-			if !ignoreAllButName {
-				tag1 = append(tag1, t)
-			}
+		for _, tag := range tags {
+			tagsBuf.WriteString(tag)
 		}
 
-		for i := 0; i < len(tag1); i++ {
-			wb.WriteUint16(reader.Days())
-			wb.WriteString(tag1[i])
-			wb.WriteBytes(name)
-			wb.WriteUVarint(uint64(tagsWritten))
-			wb.Write(tagsBuf.Bytes())
-			wb.WriteUint32(version)
+		if !ignoreAllButName {
+			tagsWritten += len(tags)
+		}
+
+		wb.WriteUint16(day)
+		wb.WriteString(mname)
+		wb.WriteBytes(name)
+		wb.WriteUVarint(uint64(tagsWritten))
+		wb.Write(tagsBuf.Bytes())
+		wb.WriteUint32(version)
+		if !ignoreAllButName {
+			for i := 0; i < len(tags); i++ {
+				wb.WriteUint16(day)
+				wb.WriteString(tags[i])
+				wb.WriteBytes(name)
+				wb.WriteUVarint(uint64(tagsWritten))
+				wb.Write(tagsBuf.Bytes())
+				wb.WriteUint32(version)
+			}
 		}
 
 		_, err = out.Write(wb.Bytes())

--- a/uploader/tagged_test.go
+++ b/uploader/tagged_test.go
@@ -3,6 +3,7 @@ package uploader
 import (
 	"fmt"
 	"net/url"
+	"sort"
 	"strconv"
 	"testing"
 
@@ -55,5 +56,98 @@ func BenchmarkKeyConcat(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		_ = strconv.Itoa(int(unum)) + ":" + path
+	}
+}
+
+func TestTagsParse(t *testing.T) {
+	assert := assert.New(t)
+
+	// make metric name as receiver
+	metric := escape.Path("instance:cpu_utilization:ratio_avg") +
+		"?" + escape.Query("dc") + "=" + escape.Query("qwe") +
+		"&" + escape.Query("fqdn") + "=" + escape.Query("asd") +
+		"&" + escape.Query("instance") + "=" + escape.Query("10.33.10.10_9100") +
+		"&" + escape.Query("job") + "=" + escape.Query("node")
+
+	assert.Equal("instance:cpu_utilization:ratio_avg?dc=qwe&fqdn=asd&instance=10.33.10.10_9100&job=node", metric)
+
+	// original url.Parse
+	m, err := url.Parse(metric)
+	assert.NotNil(m)
+	assert.NoError(err)
+	assert.Equal("", m.Path)
+
+	// from tagged uploader
+	m, err = urlParse(metric)
+	assert.NotNil(m)
+	assert.NoError(err)
+	assert.Equal("instance:cpu_utilization:ratio_avg", m.Path)
+	m.Path = "__name__=" + m.Path
+	mapTags := m.Query()
+	mTags := make([]string, len(mapTags))
+	n := 0
+	for k, v := range mapTags {
+		mTags[n] = k + "=" + v[0]
+		n++
+	}
+	sort.Strings(mTags)
+
+	name, tags, err := tagsParse(metric)
+	if err != nil {
+		t.Errorf("tagParse: %s", err.Error())
+	}
+	assert.Equal(m.Path, name)
+	assert.Equal(mTags, tags)
+}
+
+func BenchmarkNetUrlParse(b *testing.B) {
+	// make metric name as receiver
+	metric := escape.Path("instance:cpu_utilization:ratio_avg") +
+		"?" + escape.Query("dc") + "=" + escape.Query("qwe") +
+		"&" + escape.Query("fqdn") + "=" + escape.Query("asd") +
+		"&" + escape.Query("instance") + "=" + escape.Query("10.33.10.10_9100") +
+		"&" + escape.Query("job") + "=" + escape.Query("node")
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		u, _ := url.Parse(metric)
+		u.Path = "__name__=" + u.Path
+		_ = u.Query()
+	}
+}
+
+func BenchmarkUrlParse(b *testing.B) {
+	// make metric name as receiver
+	metric := escape.Path("instance:cpu_utilization:ratio_avg") +
+		"?" + escape.Query("dc") + "=" + escape.Query("qwe") +
+		"&" + escape.Query("fqdn") + "=" + escape.Query("asd") +
+		"&" + escape.Query("instance") + "=" + escape.Query("10.33.10.10_9100") +
+		"&" + escape.Query("job") + "=" + escape.Query("node")
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		u, _ := urlParse(metric)
+		u.Path = "__name__=" + u.Path
+		_ = u.Query()
+	}
+}
+
+func BenchmarkTagParse(b *testing.B) {
+	// make metric name as receiver
+	metric := escape.Path("instance:cpu_utilization:ratio_avg") +
+		"?" + escape.Query("dc") + "=" + escape.Query("qwe") +
+		"&" + escape.Query("fqdn") + "=" + escape.Query("asd") +
+		"&" + escape.Query("instance") + "=" + escape.Query("10.33.10.10_9100") +
+		"&" + escape.Query("job") + "=" + escape.Query("node")
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		_, _, _ = tagsParse(metric)
 	}
 }

--- a/uploader/tagged_test.go
+++ b/uploader/tagged_test.go
@@ -1,7 +1,9 @@
 package uploader
 
 import (
+	"fmt"
 	"net/url"
+	"strconv"
 	"testing"
 
 	"github.com/lomik/carbon-clickhouse/helper/escape"
@@ -31,4 +33,27 @@ func TestUrlParse(t *testing.T) {
 	assert.NotNil(m)
 	assert.NoError(err)
 	assert.Equal("instance:cpu_utilization:ratio_avg", m.Path)
+}
+
+func BenchmarkKeySprintf(b *testing.B) {
+	path := "test.path"
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		_ = fmt.Sprintf("%d:%s", 1285, path)
+	}
+}
+
+func BenchmarkKeyConcat(b *testing.B) {
+	path := "test.path"
+	var unum uint16 = 1245
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		_ = strconv.Itoa(int(unum)) + ":" + path
+	}
 }

--- a/vendor/github.com/msaf1980/stringutils/.travis.yml
+++ b/vendor/github.com/msaf1980/stringutils/.travis.yml
@@ -1,0 +1,5 @@
+language: go
+
+go:
+  - 1.14
+  - tip

--- a/vendor/github.com/msaf1980/stringutils/README.md
+++ b/vendor/github.com/msaf1980/stringutils/README.md
@@ -1,0 +1,11 @@
+# stringutils
+
+Some string utils
+
+`UnsafeString([]byte) string` return unsafe string from bytes slice indirectly (without allocation)
+`UnsafeStringFromPtr(*byte, length) string` return unsafe string from bytes slice pointer indirectly (without allocation)
+`UnsafeStringBytes(*string) []bytes` return unsafe string bytes indirectly (without allocation)
+
+`Split2(s string, sep string) (string, string, int)`  Split2 return the split string results (without memory allocations)
+
+`Builder` very simular to strings.Builder, but has better perfomance (at golang 1.14).

--- a/vendor/github.com/msaf1980/stringutils/split.go
+++ b/vendor/github.com/msaf1980/stringutils/split.go
@@ -1,0 +1,23 @@
+package stringutils
+
+import "strings"
+
+var empthy = ""
+
+// Split2 return the split string results (without memory allocations)
+//   If sep string not found: 's' '' 1
+//   If s or sep string is empthy: 's' '' 1
+//   In other cases: 's0' 's2' 2
+func Split2(s string, sep string) (string, string, int) {
+	if sep == "" {
+		return s, empthy, 1
+	}
+
+	if pos := strings.Index(s, sep); pos == -1 {
+		return s, empthy, 1
+	} else if pos == len(s)-1 {
+		return s[0:pos], empthy, 2
+	} else {
+		return s[0:pos], s[pos+1:], 2
+	}
+}

--- a/vendor/github.com/msaf1980/stringutils/stringbuilder.go
+++ b/vendor/github.com/msaf1980/stringutils/stringbuilder.go
@@ -1,0 +1,132 @@
+package stringutils
+
+import (
+	"unicode/utf8"
+)
+
+// A Builder is used to efficiently build a string using Write methods (with better perfomance than strings.Builder).
+// It minimizes memory copying. The zero value is ready to use.
+// Do not copy a non-zero Builder.
+type Builder struct {
+	data   []byte
+	length int
+}
+
+// grow scale factor for needed resize
+const scaleFactor = 2
+
+// Len returns the number of accumulated bytes; b.Len() == len(b.String()).
+func (sb *Builder) Len() int {
+	return sb.length
+}
+
+// Cap returns the capacity of the builder's underlying byte slice. It is the
+// total space allocated for the string being built and includes any bytes
+// already written.
+func (sb *Builder) Cap() int {
+	return len(sb.data)
+}
+
+// Bytes returns the accumulated bytes.
+func (sb *Builder) Bytes() []byte {
+	return sb.data[0:sb.length]
+}
+
+// String returns the accumulated string.
+func (sb *Builder) String() string {
+	if sb.length == 0 {
+		return ""
+	}
+	return UnsafeStringFromPtr(&sb.data[0], sb.length)
+}
+
+// Grow grows b's capacity, if necessary, to guarantee space for
+// another n bytes. After Grow(n), at least n bytes can be written to b
+// without another allocation.
+func (sb *Builder) Grow(capacity int) {
+	if capacity > sb.Cap() {
+		b := make([]byte, capacity)
+		copy(b, sb.data[0:sb.length])
+		sb.data = b
+	}
+}
+
+// Reset resets the Builder to be empty.
+func (sb *Builder) Reset() {
+	if sb.length > 0 {
+		sb.length = 0
+	}
+}
+
+// Release resets the Builder to be empty and free buffer
+func (sb *Builder) Release() {
+	if cap(sb.data) > 0 {
+		sb.data = nil
+	}
+	sb.Reset()
+}
+
+// Write appends the contents of p to b's buffer.
+func (sb *Builder) Write(bytes []byte) {
+	if len(bytes) == 0 {
+		return
+	}
+	newlen := sb.length + len(bytes)
+	if newlen > cap(sb.data) {
+		scaled := sb.length * scaleFactor
+		if newlen > scaled {
+			sb.Grow(newlen)
+		} else {
+			sb.Grow(scaled)
+		}
+	}
+	copy(sb.data[sb.length:], bytes)
+	sb.length += len(bytes)
+}
+
+// WriteString appends the contents of s to b's buffer.
+func (sb *Builder) WriteString(s string) {
+	if len(s) == 0 {
+		return
+	}
+	newlen := sb.length + len(s)
+	if newlen > cap(sb.data) {
+		scaled := sb.length * scaleFactor
+		if newlen > scaled {
+			sb.Grow(newlen)
+		} else {
+			sb.Grow(scaled)
+		}
+	}
+	copy(sb.data[sb.length:], s)
+	sb.length += len(s)
+}
+
+// WriteByte appends the byte c to b's buffer.
+func (sb *Builder) WriteByte(c byte) {
+	if sb.length == cap(sb.data) {
+		if sb.length == 0 {
+			sb.Grow(2 * scaleFactor)
+		} else {
+			sb.Grow(sb.length * scaleFactor)
+		}
+	}
+	sb.data[sb.length] = c
+	sb.length++
+}
+
+// WriteRune appends the UTF-8 encoding of Unicode code point r to b's buffer.
+func (sb *Builder) WriteRune(r rune) {
+	if r < utf8.RuneSelf {
+		sb.WriteByte(byte(r))
+	} else {
+		if sb.length+utf8.UTFMax > cap(sb.data) {
+			if sb.length > 2*utf8.UTFMax {
+				sb.Grow(sb.length * scaleFactor)
+			} else {
+				sb.Grow(sb.length + utf8.UTFMax*scaleFactor)
+			}
+		}
+		sb.length += utf8.EncodeRune(sb.data[sb.length:sb.length+utf8.UTFMax], r)
+	}
+}

--- a/vendor/github.com/msaf1980/stringutils/unsafe.go
+++ b/vendor/github.com/msaf1980/stringutils/unsafe.go
@@ -1,0 +1,25 @@
+package stringutils
+
+import (
+	"reflect"
+	"unsafe"
+)
+
+// UnsafeString returns the string under byte buffer
+func UnsafeString(b []byte) string {
+	return *(*string)(unsafe.Pointer(&b))
+}
+
+// UnsafeStringFromPtr returns the string with specific length under byte buffer
+func UnsafeStringFromPtr(ptr *byte, length int) (s string) {
+	str := (*reflect.StringHeader)(unsafe.Pointer(&s))
+	str.Data = uintptr(unsafe.Pointer(ptr))
+	str.Len = length
+
+	return s
+}
+
+// UnsafeStringBytes returns the string bytes
+func UnsafeStringBytes(s *string) []byte {
+	return *(*[]byte)(unsafe.Pointer((*reflect.SliceHeader)(unsafe.Pointer(s))))
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -35,6 +35,9 @@ github.com/lomik/stop
 # github.com/lomik/zapwriter v0.0.0-20170315193840-d4499a33b592
 ## explicit
 github.com/lomik/zapwriter
+# github.com/msaf1980/stringutils v0.0.2-0.20201020141843-69ada32f5dc0
+## explicit
+github.com/msaf1980/stringutils
 # github.com/pierrec/lz4 v2.5.2+incompatible
 ## explicit
 github.com/pierrec/lz4


### PR DESCRIPTION
Reduce allocations in uploader:

1) Modify key concatenation
```
- key := fmt.Sprintf("%d:%s", reader.Days(), unsafeString(name))
BenchmarkKeySprintf-6    	 8684433	       130 ns/op	      32 B/op	       2 allocs/op
```
```
+ key := strconv.Itoa(int(reader.Days())) + ":" + unsafeString(name)
`BenchmarkKeyConcat-6     	24734026	        48.7 ns/op	       4 B/op	       1 allocs/op
```

2) Replace urlParse for tagParse (without map for tags list)
```
net.url.Parse
BenchmarkNetUrlParse-6   	 1500700	       804 ns/op	     592 B/op	       7 allocs/op
urlParse
BenchmarkUrlParse-6      	 1000000	      1000 ns/op	     640 B/op	       8 allocs/op
tagParse
BenchmarkTagParse-6      	 6899556	       154 ns/op	     112 B/op	       2 allocs/op
```
