### PR TITLE
uploader: preallocate buffer for reverse index name

### DIFF
--- a/helper/RowBinary/reader.go
+++ b/helper/RowBinary/reader.go
@@ -82,6 +82,11 @@ func reverseMetricInplace(m []byte) {
 	reverse(m[a:b])
 }
 
+func ReverseBytesTo(dst []byte, src []byte) {
+	copy(dst, src)
+	reverseMetricInplace(dst)
+}
+
 func (r *Reader) readRecord() ([]byte, error) {
 	r.size = 0
 	r.offset = 0

--- a/helper/RowBinary/reverse_test.go
+++ b/helper/RowBinary/reverse_test.go
@@ -37,6 +37,25 @@ func TestReverseInplace(t *testing.T) {
 	}
 }
 
+func TestReverseBytesTo(t *testing.T) {
+	assert := assert.New(t)
+	table := []string{
+		"carbon.agents.carbon-clickhouse.graphite1.tcp.metricsReceived",
+		"",
+		".",
+		"carbon..xx",
+		".hello..world.",
+	}
+
+	for i := 0; i < len(table); i++ {
+		x := []byte(table[i])
+		y := make([]byte, len(table[i]))
+		z := reverseBytesOriginal(x)
+		ReverseBytesTo(y, x)
+		assert.Equal(string(z), string(y))
+	}
+}
+
 func BenchmarkReverseOriginal(b *testing.B) {
 	m := []byte("carbon.agents.carbon-clickhouse.graphite1.tcp.metricsReceived")
 	var a []byte
@@ -57,5 +76,33 @@ func BenchmarkMetricInplace(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		reverseMetricInplace(m)
+	}
+}
+
+func BenchmarkReverseBytes(b *testing.B) {
+	name := []byte("test.reverse.metric")
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		_ = ReverseBytes(name)
+	}
+}
+
+func BenchmarkReverseBytesTo(b *testing.B) {
+	name := []byte("test.reverse.metric")
+	reverseNameBuf := make([]byte, 256)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		l := len(name)
+		if l > len(reverseNameBuf) {
+			reverseNameBuf = make([]byte, 2*len(name))
+		}
+		reverseName := reverseNameBuf[0:l]
+		ReverseBytesTo(reverseName, name)
 	}
 }

--- a/uploader/index.go
+++ b/uploader/index.go
@@ -54,7 +54,7 @@ func (u *Index) parseFile(filename string, out io.Writer) (uint64, map[string]bo
 	}
 
 	reverseNameBuf := make([]byte, 256)
-  
+
 	hashFunc := u.config.hashFunc
 	if hashFunc == nil {
 		hashFunc = keepOriginal
@@ -89,13 +89,6 @@ LineLoop:
 
 		newSeries[key] = true
 
-		l = len(name)
-		if l > len(reverseNameBuf) {
-			reverseNameBuf = make([]byte, len(name)*2)
-		}
-		reverseName := reverseNameBuf[0:l]
-		RowBinary.ReverseBytesTo(reverseName, name)
-
 		// Tree
 		wb.WriteUint16(treeDate)
 		wb.WriteUint32(uint32(level + TreeLevelOffset))
@@ -121,6 +114,13 @@ LineLoop:
 		}
 
 		// Reverse path without date
+		l = len(name)
+		if l > len(reverseNameBuf) {
+			reverseNameBuf = make([]byte, len(name)*2)
+		}
+		reverseName := reverseNameBuf[0:l]
+		RowBinary.ReverseBytesTo(reverseName, name)
+
 		wb.WriteUint16(treeDate)
 		wb.WriteUint32(uint32(level + ReverseTreeLevelOffset))
 		wb.WriteBytes(reverseName)

--- a/uploader/index.go
+++ b/uploader/index.go
@@ -53,6 +53,7 @@ func (u *Index) parseFile(filename string, out io.Writer) (uint64, map[string]bo
 		treeDate = RowBinary.TimestampToDays(uint32(u.config.TreeDate.Unix()))
 	}
 
+	reverseNameBuf := make([]byte, 256)
 LineLoop:
 	for {
 		name, err := reader.ReadRecord()
@@ -88,7 +89,12 @@ LineLoop:
 		wb.WriteBytes(name)
 		wb.WriteUint32(version)
 
-		reverseName := RowBinary.ReverseBytes(name)
+		l = len(name)
+		if l > len(reverseNameBuf) {
+			reverseNameBuf = make([]byte, len(name)*2)
+		}
+		reverseName := reverseNameBuf[0:l]
+		RowBinary.ReverseBytesTo(reverseName, name)
 
 		// Reverse path with date
 		wb.WriteUint16(reader.Days())


### PR DESCRIPTION
Reduce allocations in index uploader (preallocated buffer for reverse name)
```
BenchmarkReverseBytes-6     	21052972	        55.5 ns/op	      32 B/op	       1 allocs/op
BenchmarkReverseBytesTo-6   	33742006	        35.4 ns/op	       0 B/op	       0 allocs/op
```
