### PR TITLE
receiver: minimized allocations in Base.PlainParseLine and one-pass escape

### DIFF
--- a/helper/escape/escape.go
+++ b/helper/escape/escape.go
@@ -1,11 +1,21 @@
 package escape
 
+import "github.com/msaf1980/stringutils"
+
 // Path escapes the string so it can be safely used as a URL path.
 func Path(s string) string {
 	return escape(s, encodePath)
 }
 
+func PathTo(s string, sb *stringutils.Builder) {
+	escapeTo(s, encodePath, sb)
+}
+
 // Query escapes the string so it can be safely placed inside a URL query.
 func Query(s string) string {
 	return escape(s, encodeQueryComponent)
+}
+
+func QueryTo(s string, sb *stringutils.Builder) {
+	escapeTo(s, encodeQueryComponent, sb)
 }

--- a/helper/escape/url.go
+++ b/helper/escape/url.go
@@ -5,6 +5,8 @@
 // Package url parses URLs and implements query escaping.
 package escape
 
+import "github.com/msaf1980/stringutils"
+
 // See RFC 3986. This package generally follows RFC 3986, except where
 // it deviates for compatibility reasons. When sending changes, first
 // search old issues for history on decisions. Unit tests should also
@@ -158,4 +160,29 @@ func escape(s string, mode encoding) string {
 		}
 	}
 	return string(t)
+}
+
+func escapeTo(s string, mode encoding, sb *stringutils.Builder) {
+	pos := 0
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if shouldEscape(c, mode) {
+			sb.WriteString(s[pos:i])
+			if c == ' ' && mode == encodeQueryComponent {
+				sb.WriteByte('+')
+			} else {
+				sb.WriteByte('%')
+				sb.WriteByte("0123456789ABCDEF"[c>>4])
+				sb.WriteByte("0123456789ABCDEF"[c&15])
+			}
+			pos = i + 1
+		}
+	}
+
+	if pos == 0 {
+		sb.WriteString(s)
+		return
+	} else if pos < len(s)-1 {
+		sb.WriteString(s[pos:])
+	}
 }

--- a/helper/tags/graphite.go
+++ b/helper/tags/graphite.go
@@ -1,14 +1,13 @@
 package tags
 
 import (
-	"bytes"
 	"fmt"
-	"net/url"
 	"regexp"
 	"sort"
 	"strings"
 
 	"github.com/lomik/carbon-clickhouse/helper/escape"
+	"github.com/msaf1980/stringutils"
 )
 
 type byKey []string
@@ -72,12 +71,13 @@ func Graphite(config TagConfig, s string) (string, error) {
 		}
 	}
 
-	var res bytes.Buffer
+	var res stringutils.Builder
+	res.Grow(len(s) + 10)
 
 	arr = arr[:len(arr)-toDel]
 
 	if len(arr) > 0 {
-		res.WriteString(escape.Path(arr[0]))
+		escape.PathTo(arr[0], &res)
 		res.WriteByte('?')
 	}
 
@@ -86,9 +86,9 @@ func Graphite(config TagConfig, s string) (string, error) {
 			res.WriteByte('&')
 		}
 		p := strings.Index(arr[i], "=")
-		res.WriteString(url.QueryEscape(arr[i][:p]))
+		escape.QueryTo(arr[i][:p], &res)
 		res.WriteByte('=')
-		res.WriteString(url.QueryEscape(arr[i][p+1:]))
+		escape.QueryTo(arr[i][p+1:], &res)
 	}
 
 	return res.String(), nil

--- a/receiver/plain.go
+++ b/receiver/plain.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/lomik/carbon-clickhouse/helper/RowBinary"
 	"github.com/lomik/carbon-clickhouse/helper/tags"
+	"github.com/msaf1980/stringutils"
 )
 
 // https://github.com/golang/go/issues/2632#issuecomment-66061057
@@ -91,7 +92,7 @@ func (base *Base) PlainParseLine(p []byte, now uint32) ([]byte, float64, uint32,
 	// parse tagged
 	// @TODO: parse as bytes, don't cast to string and back
 	name, err := tags.Graphite(base.Tags, unsafeString(s))
-	return []byte(name), value, timestamp, err
+	return stringutils.UnsafeStringBytes(&name), value, timestamp, err
 }
 
 func (base *Base) PlainParseBuffer(ctx context.Context, b *Buffer) {


### PR DESCRIPTION
Some perfomance optimizations for receiver:
1) One pass escape with direct write
```
BenchmarkGraphite-6   	  861072	      1325 ns/op	     288 B/op	       3 allocs/op
BenchmarkGraphiteEscaped-6   	  781430	      1446 ns/op	     592 B/op	       4 allocs/op
```
Original version
```
BenchmarkGraphite-6   	  750898	      1505 ns/op	     544 B/op	       6 allocs/op
BenchmarkGraphiteEscaped-6   	  631176	      1697 ns/op	     613 B/op	       8 allocs/op
```
2) Convert string to []bytes with unsafe method (no allocation)
```
BenchmarkPlainParseBuffer-6   	 7500656	       157 ns/op	       0 B/op	       0 allocs/op
```
Original version
```
BenchmarkPlainParseBuffer-6   	 5230838	       200 ns/op	      48 B/op	       1 allocs/op
