### PR TITLE
Add feature to disable daily index

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,8 @@ cache-ttl = "12h0m0s"
 # Store hash of metric in memory instead of full metric name
 # Allowed values: "", "city64" (empty value - disabled)
 hash = ""
+# If daily index should be disabled, default is `false`
+disable-daily-index = false
 
 # # You can define additional upload destinations of any supported type:
 # # - points

--- a/uploader/config.go
+++ b/uploader/config.go
@@ -21,6 +21,7 @@ type Config struct {
 	CompressData         bool                `toml:"compress-data"`              //compress data while sending to clickhouse
 	IgnoredTaggedMetrics []string            `toml:"ignored-tagged-metrics"`     // for tagged table; create only `__name__` tag for these metrics and ignore others
 	Hash                 string              `toml:"hash"`                       // in index uploader store hash in memory instead of full metric
+	DisableDailyIndex    bool                `toml:"disable-daily-index"`        // do not calculate and upload daily index to ClickHouse
 	hashFunc             func(string) string `toml:"-"`
 }
 

--- a/uploader/index.go
+++ b/uploader/index.go
@@ -87,20 +87,6 @@ LineLoop:
 
 		newSeries[key] = true
 
-		// Direct path with date
-		wb.WriteUint16(reader.Days())
-		wb.WriteUint32(uint32(level))
-		wb.WriteBytes(name)
-		wb.WriteUint32(version)
-
-		reverseName := RowBinary.ReverseBytes(name)
-
-		// Reverse path with date
-		wb.WriteUint16(reader.Days())
-		wb.WriteUint32(uint32(level + ReverseLevelOffset))
-		wb.WriteBytes(reverseName)
-		wb.WriteUint32(version)
-
 		// Tree
 		wb.WriteUint16(treeDate)
 		wb.WriteUint32(uint32(level + TreeLevelOffset))
@@ -126,11 +112,36 @@ LineLoop:
 		}
 
 		// Reverse path without date
+		reverseName := RowBinary.ReverseBytes(name)
 		wb.WriteUint16(treeDate)
 		wb.WriteUint32(uint32(level + ReverseTreeLevelOffset))
 		wb.WriteBytes(reverseName)
 		wb.WriteUint32(version)
 
+		// Write data with treeDate
+		_, err = out.Write(wb.Bytes())
+		if err != nil {
+			return n, nil, err
+		}
+
+		// Skip daily index
+		if u.config.DisableDailyIndex {
+			continue LineLoop
+		}
+
+		// Direct path with date
+		wb.WriteUint16(reader.Days())
+		wb.WriteUint32(uint32(level))
+		wb.WriteBytes(name)
+		wb.WriteUint32(version)
+
+		// Reverse path with date
+		wb.WriteUint16(reader.Days())
+		wb.WriteUint32(uint32(level + ReverseLevelOffset))
+		wb.WriteBytes(reverseName)
+		wb.WriteUint32(version)
+
+		// Write data with daily index
 		_, err = out.Write(wb.Bytes())
 		if err != nil {
 			return n, nil, err


### PR DESCRIPTION
With our data daily index is useless, so I have to clean it from time to time. It's a replicated table, so I have 0.5 x 20 GiB monthly.

This PR provides a way to disable the daily index completely on the carbon side.