### PR TITLE
Uploader max chunk size

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,8 +92,9 @@ level = "info"
 # Folder for buffering received data
 path = "/data/carbon-clickhouse/"
 # Rotate (and upload) file iniciated on size and interval
-# Rotate (and upload) file size
-chunk-switch-size = 0
+# Rotate (and upload) file size (in bytes, also k, m and g units can be used)
+# chunk-max-size = '512m'
+chunk-max-size = 0
 # Rotate (and upload) file interval
 # Minimize chunk-interval for minimize lag between point receive and store
 chunk-interval = "1s"

--- a/README.md
+++ b/README.md
@@ -91,7 +91,10 @@ level = "info"
 [data]
 # Folder for buffering received data
 path = "/data/carbon-clickhouse/"
-# Rotate (and upload) file interval.
+# Rotate (and upload) file iniciated on size and interval
+# Rotate (and upload) file size
+chunk-switch-size = 0
+# Rotate (and upload) file interval
 # Minimize chunk-interval for minimize lag between point receive and store
 chunk-interval = "1s"
 # Auto-increase chunk interval if the number of unprocessed files is grown

--- a/carbon/app.go
+++ b/carbon/app.go
@@ -207,6 +207,7 @@ func (app *App) Start() (err error) {
 	app.Writer = writer.New(
 		app.writeChan,
 		conf.Data.Path,
+		conf.Data.ChunkSwitchSize,
 		conf.Data.AutoInterval,
 		conf.Data.CompAlgo.CompAlgo,
 		conf.Data.CompLevel,

--- a/carbon/app.go
+++ b/carbon/app.go
@@ -207,7 +207,7 @@ func (app *App) Start() (err error) {
 	app.Writer = writer.New(
 		app.writeChan,
 		conf.Data.Path,
-		conf.Data.ChunkSwitchSize,
+		conf.Data.ChunkMaxSize.Value(),
 		conf.Data.AutoInterval,
 		conf.Data.CompAlgo.CompAlgo,
 		conf.Data.CompLevel,

--- a/carbon/config.go
+++ b/carbon/config.go
@@ -31,53 +31,53 @@ type clickhouseConfig struct {
 }
 
 type udpConfig struct {
-	Listen          string           `toml:"listen"`
-	Enabled         bool             `toml:"enabled"`
-	LogIncomplete   bool             `toml:"log-incomplete"`
-	DropFuture      *config.Duration `toml:"drop-future"`
-	DropPast        *config.Duration `toml:"drop-past"`
-	DropLongerThan  uint16           `toml:"drop-longer-than"`
+	Listen         string           `toml:"listen"`
+	Enabled        bool             `toml:"enabled"`
+	LogIncomplete  bool             `toml:"log-incomplete"`
+	DropFuture     *config.Duration `toml:"drop-future"`
+	DropPast       *config.Duration `toml:"drop-past"`
+	DropLongerThan uint16           `toml:"drop-longer-than"`
 }
 
 type tcpConfig struct {
-	Listen          string           `toml:"listen"`
-	Enabled         bool             `toml:"enabled"`
-	DropFuture      *config.Duration `toml:"drop-future"`
-	DropPast        *config.Duration `toml:"drop-past"`
-	DropLongerThan  uint16           `toml:"drop-longer-than"`
-	ReadTimeout     *config.Duration `toml:"read-timeout"`
+	Listen         string           `toml:"listen"`
+	Enabled        bool             `toml:"enabled"`
+	DropFuture     *config.Duration `toml:"drop-future"`
+	DropPast       *config.Duration `toml:"drop-past"`
+	DropLongerThan uint16           `toml:"drop-longer-than"`
+	ReadTimeout    *config.Duration `toml:"read-timeout"`
 }
 
 type pickleConfig struct {
-	Listen              string           `toml:"listen"`
-	Enabled             bool             `toml:"enabled"`
-	DropFuture          *config.Duration `toml:"drop-future"`
-	DropPast            *config.Duration `toml:"drop-past"`
-	DropLongerThan      uint16           `toml:"drop-longer-than"`
+	Listen         string           `toml:"listen"`
+	Enabled        bool             `toml:"enabled"`
+	DropFuture     *config.Duration `toml:"drop-future"`
+	DropPast       *config.Duration `toml:"drop-past"`
+	DropLongerThan uint16           `toml:"drop-longer-than"`
 }
 
 type grpcConfig struct {
-	Listen              string           `toml:"listen"`
-	Enabled             bool             `toml:"enabled"`
-	DropFuture          *config.Duration `toml:"drop-future"`
-	DropPast            *config.Duration `toml:"drop-past"`
-	DropLongerThan      uint16           `toml:"drop-longer-than"`
+	Listen         string           `toml:"listen"`
+	Enabled        bool             `toml:"enabled"`
+	DropFuture     *config.Duration `toml:"drop-future"`
+	DropPast       *config.Duration `toml:"drop-past"`
+	DropLongerThan uint16           `toml:"drop-longer-than"`
 }
 
 type promConfig struct {
-	Listen              string           `toml:"listen"`
-	Enabled             bool             `toml:"enabled"`
-	DropFuture          *config.Duration `toml:"drop-future"`
-	DropPast            *config.Duration `toml:"drop-past"`
-	DropLongerThan      uint16           `toml:"drop-longer-than"`
+	Listen         string           `toml:"listen"`
+	Enabled        bool             `toml:"enabled"`
+	DropFuture     *config.Duration `toml:"drop-future"`
+	DropPast       *config.Duration `toml:"drop-past"`
+	DropLongerThan uint16           `toml:"drop-longer-than"`
 }
 
 type telegrafHttpJsonConfig struct {
-	Listen          string           `toml:"listen"`
-	Enabled         bool             `toml:"enabled"`
-	DropFuture      *config.Duration `toml:"drop-future"`
-	DropPast        *config.Duration `toml:"drop-past"`
-	DropLongerThan  uint16           `toml:"drop-longer-than"`
+	Listen         string           `toml:"listen"`
+	Enabled        bool             `toml:"enabled"`
+	DropFuture     *config.Duration `toml:"drop-future"`
+	DropPast       *config.Duration `toml:"drop-past"`
+	DropLongerThan uint16           `toml:"drop-longer-than"`
 }
 
 type pprofConfig struct {
@@ -86,11 +86,12 @@ type pprofConfig struct {
 }
 
 type dataConfig struct {
-	Path         string                    `toml:"path"`
-	FileInterval *config.Duration          `toml:"chunk-interval"`
-	AutoInterval *config.ChunkAutoInterval `toml:"chunk-auto-interval"`
-	CompAlgo     *config.Compression       `toml:"compression"`
-	CompLevel    int                       `toml:"compression-level"`
+	Path            string                    `toml:"path"`
+	ChunkSwitchSize int64                     `toml:"chunk-switch-size"`
+	FileInterval    *config.Duration          `toml:"chunk-interval"`
+	AutoInterval    *config.ChunkAutoInterval `toml:"chunk-auto-interval"`
+	CompAlgo        *config.Compression       `toml:"compression"`
+	CompLevel       int                       `toml:"compression-level"`
 }
 
 // Config ...
@@ -140,41 +141,41 @@ func NewConfig() *Config {
 			DropLongerThan: 0,
 		},
 		Tcp: tcpConfig{
-			Listen:     ":2003",
-			Enabled:    true,
-			DropFuture: &config.Duration{},
-			DropPast:   &config.Duration{},
+			Listen:         ":2003",
+			Enabled:        true,
+			DropFuture:     &config.Duration{},
+			DropPast:       &config.Duration{},
 			DropLongerThan: 0,
 			ReadTimeout: &config.Duration{
 				Duration: 120 * time.Second,
 			},
 		},
 		Pickle: pickleConfig{
-			Listen:     ":2004",
-			Enabled:    true,
-			DropFuture: &config.Duration{},
-			DropPast:   &config.Duration{},
+			Listen:         ":2004",
+			Enabled:        true,
+			DropFuture:     &config.Duration{},
+			DropPast:       &config.Duration{},
 			DropLongerThan: 0,
 		},
 		Grpc: grpcConfig{
-			Listen:     ":2005",
-			Enabled:    false,
-			DropFuture: &config.Duration{},
-			DropPast:   &config.Duration{},
+			Listen:         ":2005",
+			Enabled:        false,
+			DropFuture:     &config.Duration{},
+			DropPast:       &config.Duration{},
 			DropLongerThan: 0,
 		},
 		Prometheus: promConfig{
-			Listen:     ":2006",
-			Enabled:    false,
-			DropFuture: &config.Duration{},
-			DropPast:   &config.Duration{},
+			Listen:         ":2006",
+			Enabled:        false,
+			DropFuture:     &config.Duration{},
+			DropPast:       &config.Duration{},
 			DropLongerThan: 0,
 		},
 		TelegrafHttpJson: telegrafHttpJsonConfig{
-			Listen:     ":2007",
-			Enabled:    false,
-			DropFuture: &config.Duration{},
-			DropPast:   &config.Duration{},
+			Listen:         ":2007",
+			Enabled:        false,
+			DropFuture:     &config.Duration{},
+			DropPast:       &config.Duration{},
 			DropLongerThan: 0,
 		},
 		Pprof: pprofConfig{

--- a/carbon/config.go
+++ b/carbon/config.go
@@ -86,12 +86,12 @@ type pprofConfig struct {
 }
 
 type dataConfig struct {
-	Path            string                    `toml:"path"`
-	ChunkSwitchSize int64                     `toml:"chunk-switch-size"`
-	FileInterval    *config.Duration          `toml:"chunk-interval"`
-	AutoInterval    *config.ChunkAutoInterval `toml:"chunk-auto-interval"`
-	CompAlgo        *config.Compression       `toml:"compression"`
-	CompLevel       int                       `toml:"compression-level"`
+	Path         string                    `toml:"path"`
+	ChunkMaxSize config.Size               `toml:"chunk-max-size"`
+	FileInterval *config.Duration          `toml:"chunk-interval"`
+	AutoInterval *config.ChunkAutoInterval `toml:"chunk-auto-interval"`
+	CompAlgo     *config.Compression       `toml:"compression"`
+	CompLevel    int                       `toml:"compression-level"`
 }
 
 // Config ...
@@ -247,7 +247,7 @@ func PrintDefaultConfig() error {
 
 // ReadConfig ...
 func ReadConfig(filename string) (*Config, error) {
-	// var err error
+	var err error
 
 	cfg := NewConfig()
 	if filename != "" {
@@ -274,7 +274,7 @@ func ReadConfig(filename string) (*Config, error) {
 		cfg.Logging = append(cfg.Logging, NewLoggingConfig())
 	}
 
-	if err := zapwriter.CheckConfig(cfg.Logging, nil); err != nil {
+	if err = zapwriter.CheckConfig(cfg.Logging, nil); err != nil {
 		return nil, err
 	}
 

--- a/helper/config/size.go
+++ b/helper/config/size.go
@@ -1,0 +1,41 @@
+package config
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+type Size int64
+
+func (u *Size) UnmarshalText(text []byte) error {
+	var err error
+	var s int64
+
+	value := strings.ToLower(string(text))
+	last := len(value) - 1
+	suffix := value[last]
+	switch suffix {
+	case 'k':
+		s, err = strconv.ParseInt(value[0:last], 10, 64)
+		s *= 1024
+	case 'm':
+		s, err = strconv.ParseInt(value[0:last], 10, 64)
+		s *= 1024 * 1024
+	case 'g':
+		s, err = strconv.ParseInt(value[0:last], 10, 64)
+		s *= 1024 * 1024 * 1024
+	default:
+		s, err = strconv.ParseInt(value, 10, 64)
+	}
+
+	if s < 0 {
+		err = fmt.Errorf("size must be greater than 0")
+	}
+	*u = Size(s)
+	return err
+}
+
+func (u *Size) Value() int64 {
+	return int64(*u)
+}

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -36,7 +36,7 @@ type Writer struct {
 	}
 	inputChan    chan *RowBinary.WriteBuffer
 	path         string
-	switchSize   int64
+	maxSize      int64
 	autoInterval *config.ChunkAutoInterval
 	compAlgo     config.CompAlgo
 	compLevel    int
@@ -63,7 +63,7 @@ func New(in chan *RowBinary.WriteBuffer, path string, switchSize int64, autoInte
 	wr := &Writer{
 		inputChan:    in,
 		path:         path,
-		switchSize:   switchSize,
+		maxSize:      switchSize,
 		autoInterval: autoInterval,
 		compAlgo:     compAlgo,
 		compLevel:    compLevel,
@@ -145,7 +145,7 @@ func (w *Writer) worker(ctx context.Context) {
 	// close old file, open new
 	rotateCheck := func() {
 		if out != nil {
-			if w.switchSize == 0 || size < w.switchSize {
+			if w.maxSize == 0 || size < w.maxSize {
 				now := time.Now()
 				prevInterval := w.autoInterval.GetDefault()
 				u := int(atomic.LoadUint32(&w.stat.unhandled))


### PR DESCRIPTION
Allow rotate chunk with max size (additional parameter to interval).
In minute range we have different metric rate (for first 10 sec heavy rate, and lower rate in other time). So first chunk is huge and smaller after (it's negative for insert perfomance, many parts in clickhouse generated).
With this parameter I can switch chunk with optimal chunk size (with failback interval, if small metric count was received).
Like this

Before
```
[data]
..
chunk-interval = "10s"
```

After
```
[data]
..
chunk-switch-size = MAX_SIZE
chunk-interval = "20s"
```
