### PR TITLE
add tzdata for setting timezone in container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN make
 
 FROM alpine:latest
 
-RUN apk --no-cache add ca-certificates
+RUN apk --no-cache add ca-certificates tzdata
 WORKDIR /
 
 COPY --from=builder /go/src/github.com/lomik/carbon-clickhouse/carbon-clickhouse ./usr/bin/carbon-clickhouse


### PR DESCRIPTION
пакет должен быть установлен, чтобы можно было устанавливать таймзону в контейнере. иначе будут артефакты на рубеже суток, когда точки за новые сутки попажают в прошлые и не отображаются на интервалах, меньше разницы между UTC и текущим часовым поясом